### PR TITLE
Fix for deploy script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,10 +36,13 @@ test_script:
 deploy_script:
   - sh: |
       echo $APPVEYOR_REPO_BRANCH - $APPVEYOR_REPO_TAG
-      if [ "$APPVEYOR_REPO_BRANCH" == "master" ] && [ "$APPVEYOR_REPO_TAG" == "true" ]; then
+      echo $GitVersion_SemVer
+      if [ "$APPVEYOR_REPO_BRANCH" == "feature/fix-script" ] && [ "$APPVEYOR_REPO_TAG" == "false" ]; then
         docker login -u=$DOCKER_USER -p=$DOCKER_PASS
         docker push datadock/web:$GitVersion_SemVer
         docker push datadock/web:latest
         docker push datadock/worker:$GitVersion_SemVer
         docker push datadock/worker:latest
+      else
+        echo "Deployment will only run on a tag on the master branch"
       fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ deploy_script:
   - sh: |
       echo $APPVEYOR_REPO_BRANCH - $APPVEYOR_REPO_TAG
       echo $GitVersion_SemVer
-      if [ "$APPVEYOR_REPO_BRANCH" == "feature/fix-script" ] && [ "$APPVEYOR_REPO_TAG" == "false" ]; then
+      if [ "$APPVEYOR_REPO_BRANCH" == "feature/fix-script" ] && [ "$APPVEYOR_REPO_TAG" == "true" ]; then
         docker login -u=$DOCKER_USER -p=$DOCKER_PASS
         docker push datadock/web:$GitVersion_SemVer
         docker push datadock/web:latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,14 +35,12 @@ test_script:
 
 deploy_script:
   - sh: |
-      echo $APPVEYOR_REPO_BRANCH - $APPVEYOR_REPO_TAG
-      echo $GitVersion_SemVer
-      if [ "$APPVEYOR_REPO_BRANCH" == "feature/fix-script" ] && [ "$APPVEYOR_REPO_TAG" == "true" ]; then
+      if [ "$APPVEYOR_REPO_TAG" == "true" ]; then
         docker login -u=$DOCKER_USER -p=$DOCKER_PASS
         docker push datadock/web:$GitVersion_SemVer
         docker push datadock/web:latest
         docker push datadock/worker:$GitVersion_SemVer
         docker push datadock/worker:latest
       else
-        echo "Deployment will only run on a tag on the master branch"
+        echo "Deployment will only run on a tag"
       fi


### PR DESCRIPTION
Finally got the script working. What I hadn't noticed was that when the repo is tagged, AppVeyor sets APPVEYOR_REPO_BRANCH to the name of the tag, not to the name of the branch that was tagged, so the test for branch=master and tag=true would never work.

This PR changes the guard so that the deployment runs whenever the repo is tagged. In general we will only be tagging code on master anyway.