### PR TITLE
Consolidate docker-compose and support ES snapshots

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ before_build:
   - sh: |
       dotnet restore src/DataDock.sln
       mono gitversion/GitVersion.exe /l console /output buildserver /updateassemblyinfo
-      export DockerImageVersion=$(mono gitversion/GitVersion.exe /output json /showVariable FullSemVer)
+      export DockerImageVersion=$(mono gitversion/GitVersion.exe /output json /showVariable SemVer)
       echo $DockerImageVersion
 
 configuration: Release

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
+      - path.repo=/usr/share/elasticsearch/backup
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:
       memlock:
@@ -16,10 +17,8 @@ services:
       - es-data-1:/usr/share/elasticsearch/data
       - es-logs-1:/usr/share/elasticsearch/logs
       - es-backup:/usr/share/elasticsearch/backup
-    ports:
-      - 9200:9200
 
-  datadock_web:
+  web:
     image: datadock/web
     depends_on:
       - elasticsearch
@@ -27,7 +26,7 @@ services:
       context: web
       dockerfile: Dockerfile
 
-  datadock_worker:
+  worker:
     image: datadock/worker
     depends_on:
       - elasticsearch

--- a/src/DataDock.sln
+++ b/src/DataDock.sln
@@ -11,11 +11,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataDock.Worker", "DataDock
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataDock.Common", "DataDock.Common\DataDock.Common.csproj", "{3B7619F9-2AEA-4E2D-9B48-93C1F2B5CCCB}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Elasticsearch", "Elasticsearch", "{5AA83009-F0E4-4C30-9FD7-C673A86C3067}"
-	ProjectSection(SolutionItems) = preProject
-		Elasticsearch\Dockerfile = Elasticsearch\Dockerfile
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "IntegrationTests", "IntegrationTests", "{E88F117F-AAC8-447E-B97D-0104D07E26DA}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataDock.Common.Tests", "DataDock.Common.Tests\DataDock.Common.Tests.csproj", "{203E241C-D2E7-4F58-8AFA-469F91F4EF04}"

--- a/src/Elasticsearch/Dockerfile
+++ b/src/Elasticsearch/Dockerfile
@@ -1,18 +1,2 @@
-FROM openjdk:8
-
-RUN useradd -ms /bin/bash elastic
-USER elastic
-WORKDIR /home/elastic
-RUN mkdir data && \
-	mkdir logs && \
-	mkdir backup && \
-	curl -L -O -k https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.2.2.tar.gz && \
-    tar -xvf elasticsearch-6.2.2.tar.gz && \
-	rm elasticsearch-6.2.2.tar.gz
-
-COPY config /home/elastic/config
-ENV ES_PATH_CONF=/home/elastic/config
-
-WORKDIR /home/elastic/elasticsearch-6.2.2/bin
-EXPOSE 9200
-CMD ./elasticsearch --E network.host=0.0.0.0
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.1
+COPY --chown=elasticsearch:elasticsearch config /usr/share/elasticsearch/config

--- a/src/Elasticsearch/config/elasticsearch.yml
+++ b/src/Elasticsearch/config/elasticsearch.yml
@@ -30,21 +30,21 @@ cluster.name: datadock
 #
 # Path to directory where to store the data (separate multiple locations by comma):
 #
-path.data: /home/elastic/data
+path.data: /usr/share/elasticsearch/data
 #
 # Path to log files:
 #
-path.logs: /home/elastic/logs
+path.logs: /usr/share/elasticsearch/logs
 
 # Path to backup volume
-path.repo: ["/home/elastic/backup"]
+path.repo: ["/tmp", "/usr/share/elasticsearch/backup"]
 
 #
 # ----------------------------------- Memory -----------------------------------
 #
 # Lock the memory on startup:
 #
-#bootstrap.memory_lock: true
+# bootstrap.memory_lock: true
 #
 # Make sure that the heap size is set to about half the memory available
 # on the system and that the owner of the process is allowed to use this
@@ -56,7 +56,7 @@ path.repo: ["/home/elastic/backup"]
 #
 # Set the bind address to a specific IP (IPv4 or IPv6):
 #
-#network.host: 192.168.0.1
+network.host: 0.0.0.0
 #
 # Set a custom port for HTTP:
 #

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -1,11 +1,11 @@
 version: '3.4'
 
 services:
-  datadock.worker:
+  worker:
     environment:
       - DD_ENVIRONMENT=Development
 
-  datadock.web:
+  web:
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
     ports:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 
 services:
-  datadock.web:
+  web:
     image: datadock.web
     volumes:
       - dd-files:/datadock
@@ -9,7 +9,7 @@ services:
       context: .
       dockerfile: DataDock.Web/Dockerfile
 
-  datadock.worker:
+  worker:
     image: datadock.worker
     volumes:
       - dd-files:/datadock
@@ -20,14 +20,21 @@ services:
       dockerfile: DataDock.Worker/Dockerfile
 
   elasticsearch:
-    image: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.1
+    container_name: elasticsearch
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - path.repo=/usr/share/elasticsearch/backup
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     volumes:
-      - es-data-1:/home/elastic/data
-      - es-logs-1:/home/elastic/logs
-      - es-backup:/home/elastic/backup
-    build:
-      context: Elasticsearch
-      dockerfile: Dockerfile
+      - es-data-1:/usr/share/elasticsearch/data
+      - es-logs-1:/usr/share/elasticsearch/logs
+      - es-backup:/usr/share/elasticsearch/backup
 
   kibana:
     image: docker.elastic.co/kibana/kibana-oss:6.2.2


### PR DESCRIPTION
Changed ES image to include a setting for the backup location
Renamed core DD services to web and worker
Use the same ES configuration for development and deployment
Remove the old ES configuration that was used in development.