### PR TITLE
Revert logic for generating aboutUrl

### DIFF
--- a/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
@@ -1105,7 +1105,7 @@ var templateMetadata;
     }
 
     function camelize(str) {
-        var camelised = str.split(" ").map(function(word, index) {
+        var camelised = str.split(/[\s_\-]/).map(function(word, index) {
             if (index === 0) {
                 return word.toLowerCase();
             }

--- a/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
@@ -153,8 +153,7 @@ var templateMetadata;
 
         csvw["dc:license"] = $("#datasetLicense").val();
 
-        var suffix = $("#aboutUrlSuffix").val();
-        var aboutUrl = datasetId.replace("/dataset/", "/resource/") + "/" + suffix;
+        var aboutUrl = $('#aboutUrlSuffix').val();
         csvw["aboutUrl"] = aboutUrl;
 
         csvw["tableSchema"] = constructCsvwtableSchema();
@@ -631,7 +630,8 @@ var templateMetadata;
 
     function constructIdentifiersTabContent() {
         var prefix = getPrefix();
-        var idFromFilename = prefix + "/id/dataset/" + slugify(filename, "", "", "camelCase");
+        var datasetId = slugify(filename, "", "", "camelCase");
+        var idFromFilename = prefix + "/id/dataset/" + datasetId;
         var defaultValue = getMetadataDatasetId(idFromFilename);
 
         var dsIdTable = {
@@ -701,14 +701,15 @@ var templateMetadata;
                 ]
             }
         );
-        var rowIdentifier = "row_{_row}";
+
+        var rowIdentifier = getIdentifierPrefix() + "/" + datasetId + "/row_{_row}";
         var identifierOptions = {};
         identifierOptions[rowIdentifier] = "Row Number";
 
         for (var colIdx = 0; colIdx < columnCount; colIdx++) {
             var colTitle = header[colIdx];
             var colName = slugify(colTitle, "_", "_", "lowercase");
-            var colIdentifier = colName + "/{" + colName + "}";
+            var colIdentifier = getIdentifierPrefix() + "/" + colName + "/{" + colName + "}";
             identifierOptions[colIdentifier] = colTitle;
         }
         identifierTableElements.push(
@@ -1079,6 +1080,10 @@ var templateMetadata;
 //helper functions
     function getPrefix() {
         return publishUrl + "/" + ownerId + "/" + repoId;
+    }
+
+    function getIdentifierPrefix() {
+        return getPrefix() + "/id/resource";
     }
 
     function slugify(original, whitespaceReplacement, specCharReplacement, casing) {

--- a/src/docker-compose.override.yml
+++ b/src/docker-compose.override.yml
@@ -7,7 +7,7 @@ services:
 
   web:
     environment:
-      - ASPNETCORE_ENVIRONMENT=Production
+      - ASPNETCORE_ENVIRONMENT=Development
     ports:
       - "5000:80"
 


### PR DESCRIPTION
This PR changes the logic for generating the aboutUrl back to the same as the old version of DD. If the user selects to use a column from the spreadsheet then the aboutUrl does not include the datasetId. The dataset id is only included in aboutUrl when using the row number.