### PR TITLE
Added optional configuration for SignalR connection

### DIFF
--- a/src/DataDock.IntegrationTests/WorkerStartupTests.cs
+++ b/src/DataDock.IntegrationTests/WorkerStartupTests.cs
@@ -28,7 +28,7 @@ namespace DataDock.IntegrationTests
         [InlineData(typeof(IRepoSettingsStore), typeof(RepoSettingsStore))]
         [InlineData(typeof(IDataDockRepositoryFactory), typeof(DataDockRepositoryFactory))]
         [InlineData(typeof(IGitCommandProcessorFactory), typeof(GitCommandProcessorFactory))]
-        [InlineData(typeof(IProgressLogFactory), typeof(SignalrProgressLogFactory))]
+        [InlineData(typeof(IProgressLogFactory), typeof(SignalRProgressLogFactory))]
         [InlineData(typeof(IDataDockUriService), typeof(DataDockUriService))]
         public void ItProvidesExpectedServices(Type serviceType, Type expectImplType)
         {

--- a/src/DataDock.Worker.Tests/WorkerConfigurationTests.cs
+++ b/src/DataDock.Worker.Tests/WorkerConfigurationTests.cs
@@ -35,7 +35,7 @@ namespace DataDock.Worker.Tests
             appConfig.GitHubClientHeader.Should().Be("");
             appConfig.PublishUrl.Should().Be("http://datadock.io/");
             appConfig.RepoBaseDir.Should().Be("/datadock/repositories");
-
+            appConfig.SignalRHubUrl.Should().Be("http://web/progress");
         }
         [Fact]
         public void ItCanReadFromJson()
@@ -60,6 +60,7 @@ namespace DataDock.Worker.Tests
             appConfig.GitHubClientHeader.Should().Be("MyDataDock");
             appConfig.PublishUrl.Should().Be("http://mydatadock.com/");
             appConfig.RepoBaseDir.Should().Be("/data/repos");
+            appConfig.SignalRHubUrl.Should().Be("http://datadock.web/progress");
         }
     }
 

--- a/src/DataDock.Worker.Tests/data/config/testSettings.json
+++ b/src/DataDock.Worker.Tests/data/config/testSettings.json
@@ -10,5 +10,6 @@
   "PublishUrl": "http://mydatadock.com/",
   "GitPath": "/usr/bin/git",
   "RepoBaseDir": "/data/repos",
-  "GitHubClientHeader": "MyDataDock" 
+  "GitHubClientHeader": "MyDataDock",
+  "SignalRHubUrl":  "http://datadock.web/progress" 
 }

--- a/src/DataDock.Worker/SignalrProgressLog.cs
+++ b/src/DataDock.Worker/SignalrProgressLog.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using DataDock.Common.Models;
 using DataDock.Common.Stores;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -9,7 +7,7 @@ using Serilog;
 
 namespace DataDock.Worker
 {
-    public class SignalrProgressLog : IProgressLog
+    public class SignalRProgressLog : IProgressLog
     {
         private readonly JobInfo _jobInfo;
         private readonly IJobStore _jobRepository;
@@ -17,7 +15,7 @@ namespace DataDock.Worker
         private readonly ILogger _log;
         private readonly StringBuilder _fullLog;
 
-        public SignalrProgressLog(JobInfo jobInfo, IJobStore jobRepository, HubConnection hubConnection)
+        public SignalRProgressLog(JobInfo jobInfo, IJobStore jobRepository, HubConnection hubConnection)
         {
             _jobInfo = jobInfo;
             _jobRepository = jobRepository;

--- a/src/DataDock.Worker/Startup.cs
+++ b/src/DataDock.Worker/Startup.cs
@@ -71,7 +71,7 @@ namespace DataDock.Worker
             serviceCollection.AddSingleton<IOwnerSettingsStore, OwnerSettingsStore>();
             serviceCollection.AddSingleton<IRepoSettingsStore, RepoSettingsStore>();
             serviceCollection.AddSingleton<ISchemaStore, SchemaStore>();
-            serviceCollection.AddSingleton<IProgressLogFactory, SignalrProgressLogFactory>();
+            serviceCollection.AddSingleton<IProgressLogFactory, SignalRProgressLogFactory>();
             serviceCollection.AddSingleton<ILogStore, DirectoryLogStore>();
             serviceCollection.AddSingleton<IGitHubClientFactory>(new GitHubClientFactory(config.GitHubClientHeader));
             serviceCollection.AddSingleton<IGitWrapperFactory>(new DefaultGitWrapperFactory(config.GitPath));

--- a/src/DataDock.Worker/WorkerConfiguration.cs
+++ b/src/DataDock.Worker/WorkerConfiguration.cs
@@ -15,6 +15,11 @@ namespace DataDock.Worker
         /// </summary>
         public string RepoBaseDir { get; set; } = "/datadock/repositories";
 
+        /// <summary>
+        /// The URL of the SignalR hub to send progress messages to
+        /// </summary>
+        public string SignalRHubUrl { get; set; } = "http://web/progress";
+
         public override void LogSettings()
         {
             base.LogSettings();
@@ -22,6 +27,7 @@ namespace DataDock.Worker
             Log.Information("Configured Git Path {GitPath}", GitPath);
             Log.Information("Configured Repository Base Directory {RepoBaseDir}", RepoBaseDir);
             Log.Information("Configured GitHub Client Header {GitHubClientHeader}", GitHubClientHeader);
+            Log.Information("Configured SignalR Hub Url {SignalRHubUrl}", SignalRHubUrl);
         }
     }
 }


### PR DESCRIPTION
The property SignalRHubUrl can be used in the worker configuration to specify the URL to connect to on the web role. This defaults to http://web/progress which will work with our default docker-compose settings.

Fixes #79 