### PR TITLE
Extended search functionality

### DIFF
--- a/src/DataDock.Common/Stores/IDatasetStore.cs
+++ b/src/DataDock.Common/Stores/IDatasetStore.cs
@@ -67,10 +67,10 @@ namespace DataDock.Common.Stores
         /// <remarks>Currently implemented as an exact match on tag string</remarks>
         /// <param name="ownerId"></param>
         /// <param name="tags">An array of one or more tags to match</param>
-        /// <param name="take"></param>
         /// <param name="matchAll">True to require a matching dataset to match all of the specified tags, false to require a matching dataset to match any one of the specified tags. Defaults to false</param>
         /// <param name="showHidden">True to include datasets that are hidden from the DD homepage in the results. Default to false</param>
-        /// <param name="skip"></param>
+        /// <param name="skip">The number of results to skip</param>
+        /// <param name="take">The number of results to return</param>
         /// <returns></returns>
         Task<IEnumerable<DatasetInfo>> GetDatasetsForTagsAsync(string ownerId, string[] tags, int skip, int take, bool matchAll = false, bool showHidden = false);
 
@@ -83,6 +83,8 @@ namespace DataDock.Common.Stores
         /// <param name="tags">An array of one or more tags to match</param>
         /// <param name="matchAll">True to require a matching dataset to match all of the specified tags, false to require a matching dataset to match any one of the specified tags. Defaults to false</param>
         /// <param name="showHidden">True to include datasets that are hidden from the DD homepage in the results. Default to false</param>
+        /// <param name="skip">The number of results to skip</param>
+        /// <param name="take">The number of results to return</param>
         /// <returns></returns>
         Task<IEnumerable<DatasetInfo>> GetDatasetsForTagsAsync(string ownerId, string repositoryId, string[] tags, int skip, int take, bool matchAll = false, bool showHidden = false);
 
@@ -96,5 +98,14 @@ namespace DataDock.Common.Stores
         Task<bool> DeleteDatasetsForOwnerAsync(string ownerId);
 
         Task<bool> DeleteDatasetAsync(string ownerId, string repositoryId, string datasetId);
+
+        /// <summary>
+        /// Search for datasets matching the specified search string in tags, title or description
+        /// </summary>
+        /// <param name="searchString"></param>
+        /// <param name="skip">The number of results to skip</param>
+        /// <param name="take">The number of results to return</param>
+        /// <returns></returns>
+        Task<IEnumerable<DatasetInfo>> SearchDatasetsAsync(string searchString, int skip, int take);
     }
 }

--- a/src/DataDock.IntegrationTests/DatasetStoreTests.cs
+++ b/src/DataDock.IntegrationTests/DatasetStoreTests.cs
@@ -89,7 +89,10 @@ namespace DataDock.IntegrationTests
                         {
                             tags.Add("foo");
                         }
-                        var csvwJson = new JObject(new JProperty("dc:title", $"Test Dataset {d} (Owner {o} Repo {r})"), new JProperty("dcat:keyword", new JArray(tags)));
+
+                        var csvwJson = new JObject(new JProperty("dc:title", $"Test Dataset {d} (Owner {o} Repo {r})"),
+                            new JProperty("dc:description", $"Dataset description {o}.{r}.{d}"),
+                            new JProperty("dcat:keyword", new JArray(tags)));
                         var voidJson = new JObject(
                             new JProperty("void:triples", "100"),
                             new JProperty("void:dataDump", 
@@ -372,5 +375,22 @@ namespace DataDock.IntegrationTests
 
             Assert.StartsWith($"No datasets found for repository owner-0/repo-0 with tags set-3, foo", ex.Result.Message);
         }
+
+        [Fact]
+        public async void ItCanSearchOnDescription()
+        {
+            var result = await _store.SearchDatasetsAsync("description", 0, 200);
+            result.Should().NotBeNull();
+            result.Count().Should().Be(125); // All datasets contain the text "description" in the description field
+        }
+
+        [Fact]
+        public async void ItCanSearchOnTitle()
+        {
+            var result = await _store.SearchDatasetsAsync("test", 0, 200);
+            result.Should().NotBeNull();
+            result.Count().Should().Be(125); // All datasets contain the text "test" in the title field
+        }
+
     }
 }

--- a/src/DataDock.Web/Controllers/SearchController.cs
+++ b/src/DataDock.Web/Controllers/SearchController.cs
@@ -28,7 +28,8 @@ namespace DataDock.Web.Controllers
                 if (!string.IsNullOrEmpty(tag))
                 {
                     var tags = new [] {tag};
-                    var results = await _datasetStore.GetDatasetsForTagsAsync(tags, skip, take);
+                    //var results = await _datasetStore.GetDatasetsForTagsAsync(tags, skip, take);
+                    var results = await _datasetStore.SearchDatasetsAsync(tag, skip, take);
                     model = new SearchResultViewModel(tag, results);
                 }
             }


### PR DESCRIPTION
Added a method to the IDatasetStore interface that takes a search string and searches against title and description as well as tags. Changed the search controller to use this method rather than pure tag search. The fields are boosted as follows:
tags  x 2.0
title  x 1.5
description x 1.0
