### PR TITLE
Feature/signalr notifications

### DIFF
--- a/src/DataDock.Web/Services/ProgressHub.cs
+++ b/src/DataDock.Web/Services/ProgressHub.cs
@@ -15,9 +15,9 @@ namespace DataDock.Web.Services
         /// <param name="jobId">The ID of the job</param>
         /// <param name="progressMessage">The progress message</param>
         /// <returns></returns>
-        public async Task ProgressUpdated(string ownerId, string jobId, string progressMessage)
+        public async Task ProgressUpdated(string ownerId, string repoId, string jobId, string progressMessage)
         {
-            await Clients.Group(ownerId).SendAsync("progressUpdated", ownerId, jobId, progressMessage);
+            await Clients.Groups(ownerId, ownerId + "_" + repoId).SendAsync("progressUpdated", ownerId, jobId, progressMessage);
         }
 
         /// <summary>
@@ -27,9 +27,9 @@ namespace DataDock.Web.Services
         /// <param name="jobId">The ID of the job</param>
         /// <param name="jobStatus">The new status of the job</param>
         /// <returns></returns>
-        public async Task StatusUpdated(string ownerId, string jobId, JobStatus jobStatus)
+        public async Task StatusUpdated(string ownerId, string repoId, string jobId, JobStatus jobStatus)
         {
-            await Clients.Group(ownerId).SendAsync("statusUpdated", ownerId, jobId, jobStatus);
+            await Clients.Groups(ownerId, ownerId + "_" + repoId).SendAsync("statusUpdated", ownerId, jobId, jobStatus);
         }
 
         /// <summary>
@@ -46,12 +46,13 @@ namespace DataDock.Web.Services
         /// <summary>
         /// Broadcast a notification of an update to a dataset or creation of a new dataset to all subscribed clients
         /// </summary>
-        /// <param name="ownerId">The ID of the owner of the repository where the dataset is located. This is used as the ID of the group that will receive the broadcast</param>
+        /// <param name="ownerId">The ID of the owner of the repository where the dataset is located.</param>
+        /// <param name="repoId">The ID of the repository where the dataset is located</param>
         /// <param name="datasetInfo">The metadata for the updated dataset</param>
         /// <returns></returns>
-        public async Task DatasetUpdated(string ownerId, DatasetInfo datasetInfo)
+        public async Task DatasetUpdated(string ownerId, string repoId, DatasetInfo datasetInfo)
         {
-            await Clients.Group(ownerId).SendAsync("datasetUpdated", ownerId, datasetInfo);
+            await Clients.Groups(ownerId, ownerId + "_" + repoId).SendAsync("datasetUpdated", ownerId, repoId, datasetInfo);
         }
 
         /// <summary>
@@ -63,25 +64,7 @@ namespace DataDock.Web.Services
         /// <returns></returns>
         public async Task DatasetDeleted(string ownerId, string repoId, string datasetId)
         {
-            await Clients.Group(ownerId).SendAsync("datasetDeleted", ownerId, repoId, datasetId);
-        }
-
-        public override async Task OnConnectedAsync()
-        {
-            try
-            {
-                // By default we always subscribe to the group for the logged in user
-                if (Context.User?.Identity?.Name != null)
-                {
-                    await Subscribe(Context.User.Identity.Name);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error in ProgressHub.OnConnectedAsync");
-            }
-
-            await base.OnConnectedAsync();
+            await Clients.Groups(ownerId, ownerId + "_" + repoId).SendAsync("datasetDeleted", ownerId, repoId, datasetId);
         }
 
         /// <summary>

--- a/src/DataDock.Web/Services/ProgressHub.cs
+++ b/src/DataDock.Web/Services/ProgressHub.cs
@@ -2,39 +2,110 @@
 using DataDock.Common.Models;
 using Microsoft.AspNetCore.SignalR;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace DataDock.Web.Services
 {
     public class ProgressHub : Hub
     {
-        public async Task ProgressUpdated(string userId, string jobId, string progressMessage)
+        /// <summary>
+        /// Broadcast a job progress update to all subscribed clients
+        /// </summary>
+        /// <param name="ownerId">The ID of the owner of the repository where the job is running</param>
+        /// <param name="jobId">The ID of the job</param>
+        /// <param name="progressMessage">The progress message</param>
+        /// <returns></returns>
+        public async Task ProgressUpdated(string ownerId, string jobId, string progressMessage)
         {
-            await Clients.Group(userId).SendAsync("progressUpdated", userId, jobId, progressMessage);
+            await Clients.Group(ownerId).SendAsync("progressUpdated", ownerId, jobId, progressMessage);
         }
 
-        public async Task StatusUpdated(string userId, string jobId, JobStatus jobStatus)
+        /// <summary>
+        /// Broadcast a job status update to all subscribed clients
+        /// </summary>
+        /// <param name="ownerId">The ID of the owner of the repository where the job is running</param>
+        /// <param name="jobId">The ID of the job</param>
+        /// <param name="jobStatus">The new status of the job</param>
+        /// <returns></returns>
+        public async Task StatusUpdated(string ownerId, string jobId, JobStatus jobStatus)
         {
-            await Clients.Group(userId).SendAsync("statusUpdated", userId, jobId, jobStatus);
+            await Clients.Group(ownerId).SendAsync("statusUpdated", ownerId, jobId, jobStatus);
         }
 
-        public async Task SendMessage(string userId, string message)
+        /// <summary>
+        /// Broadcast a message to all subscribed clients
+        /// </summary>
+        /// <param name="ownerId">The ID of the owner of the repository/repositories affected by this message</param>
+        /// <param name="message">The message content</param>
+        /// <returns></returns>
+        public async Task SendMessage(string ownerId, string message)
         {
-            await Clients.Group(userId).SendAsync("sendMessage", userId, message);
+            await Clients.Group(ownerId).SendAsync("sendMessage", ownerId, message);
+        }
+
+        /// <summary>
+        /// Broadcast a notification of an update to a dataset or creation of a new dataset to all subscribed clients
+        /// </summary>
+        /// <param name="ownerId">The ID of the owner of the repository where the dataset is located. This is used as the ID of the group that will receive the broadcast</param>
+        /// <param name="datasetInfo">The metadata for the updated dataset</param>
+        /// <returns></returns>
+        public async Task DatasetUpdated(string ownerId, DatasetInfo datasetInfo)
+        {
+            await Clients.Group(ownerId).SendAsync("datasetUpdated", ownerId, datasetInfo);
+        }
+
+        /// <summary>
+        /// Broadcast a notification of a deletion of a dataset to all subscribed clients
+        /// </summary>
+        /// <param name="ownerId"></param>
+        /// <param name="repoId"></param>
+        /// <param name="datasetId"></param>
+        /// <returns></returns>
+        public async Task DatasetDeleted(string ownerId, string repoId, string datasetId)
+        {
+            await Clients.Group(ownerId).SendAsync("datasetDeleted", ownerId, repoId, datasetId);
         }
 
         public override async Task OnConnectedAsync()
         {
             try
             {
-                var name = Context.User.Identity.Name;
-                await Groups.AddToGroupAsync(Context.ConnectionId, name);
+                // By default we always subscribe to the group for the logged in user
+                if (Context.User?.Identity?.Name != null)
+                {
+                    await Subscribe(Context.User.Identity.Name);
+                }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                // A connection from the worker role will not have a user identity
+                Log.Error(ex, "Error in ProgressHub.OnConnectedAsync");
             }
 
             await base.OnConnectedAsync();
+        }
+
+        /// <summary>
+        /// Subscribe the client connection to the specified group
+        /// </summary>
+        /// <remarks>This method can be used from the client to subscribe to the group providing progress messages for an organization</remarks>
+        /// <param name="groupId">The name of the organization whose messages we want to subscribe to</param>
+        /// <returns></returns>
+        public async Task Subscribe(string groupId)
+        {
+            try
+            {
+                if (groupId == null)
+                {
+                    Log.Warning("ProgressHub.Subscribe received a null groupId. Request was ignored");
+                    return;
+                }
+                await Groups.AddToGroupAsync(Context.ConnectionId, groupId);
+                Log.Information("ProgressHub subscribed connection {ConnectionId} to group {GroupId}", Context.ConnectionId, groupId);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Error in ProgressHub.Subscribe");
+            }
         }
     }
 }

--- a/src/DataDock.Web/Views/Shared/Dashboard/Datasets.cshtml
+++ b/src/DataDock.Web/Views/Shared/Dashboard/Datasets.cshtml
@@ -16,22 +16,67 @@
     </div>
 </div>
 
-@section Scripts { 
-  <script type="text/javascript">
-      $(document).ready(function() { refresh() });
+@section Scripts {
 
-      function refresh() {
-          $('.data-loader').each(function() {
-              var endpoint = $(this).data('endpoint');
-              var container = this;
-              $.ajax({
-                  type: "GET",
-                  url: endpoint
-              }).done(function(data) {
-                  $(container).html(data);
-              });
-          });
-          setTimeout(function() { refresh(); }, 5000);
-      }
-  </script>
+<environment names="Development">
+    <script src="~/lib/signalr/signalr.js"></script>
+</environment>
+<environment names="Staging,Production">
+    <script src="~/lib/signalr/signalr.min.js"></script>
+</environment>
+
+<script>
+    $(function () {
+        refresh();
+        var connection = new signalR.HubConnectionBuilder().withUrl('/progress')
+            .configureLogging(signalR.LogLevel.Information).build();
+        connection.on('datasetUpdated',
+            function(ownerId, repoId, datasetInfo) {
+                console.log(ownerId, repoId, datasetInfo);
+                refresh();
+            });
+        connection.on('datasetDeleted',
+            function (ownerId, repoId, datasetId) {
+                console.log(ownerId, repoId, datasetId);
+                refresh();
+            });
+        connection.on('sendMessage', function() {});
+        connection.on('statusUpdated', function () { });
+        connection.on('progressUpdated', function() {});
+        connection.start().then(() => {
+            @{
+                if (String.IsNullOrEmpty(Model.SelectedRepoId))
+                {
+                    <text>
+                        console.log('Subscribe to channel: @(Model.SelectedOwnerId)');
+                        connection.invoke('subscribe', '@(Model.SelectedOwnerId)');
+                    </text>
+                }
+                else
+                {
+                    <text>
+                        console.log('Subscribe to channel: @(Model.SelectedOwnerId)_@(Model.SelectedRepoId)');
+                        connection.invoke('subscribe', '@(Model.SelectedOwnerId)_@(Model.SelectedRepoId)');
+                    </text>
+                }
+            }
+
+        });
+
+    });
+
+    function refresh() {
+        $('.data-loader').each(function() {
+            var endpoint = $(this).data('endpoint');
+            var container = this;
+            $.ajax({
+                type: "GET",
+                url: endpoint
+            }).done(function(data) {
+                $(container).html(data);
+            });
+        });
+    }
+
+</script>
 }

--- a/src/DataDock.Web/Views/Shared/Dashboard/Index.cshtml
+++ b/src/DataDock.Web/Views/Shared/Dashboard/Index.cshtml
@@ -5,42 +5,98 @@
 }
 
 <div class="ui grid">
-  <div class="eight wide column">
-    <h3>Datasets</h3>
-      <div class="data-loader"
-           data-endpoint="@Url.RouteUrl("DatasetsLoader", new {ownerId = @Model.SelectedOwnerId, repoId = @Model.SelectedRepoId})">
-          <div id="loadingJobs">
-              @await Html.PartialAsync("_SpinnerPartial")
-          </div>
-      </div>
-  </div>
-  <div class="eight wide column">
-      <h3>Jobs</h3>
-      <div class="data-loader"
-           data-endpoint="@Url.RouteUrl("JobsLoader", new {ownerId = @Model.SelectedOwnerId, repoId = @Model.SelectedRepoId})">
-          <div id="loadingJobs">
-              @await Html.PartialAsync("_SpinnerPartial")
-          </div>
-      </div>
-  </div>
+    <div class="eight wide column">
+        <h3>Datasets</h3>
+        <div id="datasets" class="data-loader"
+             data-endpoint="@Url.RouteUrl("DatasetsLoader", new {ownerId = @Model.SelectedOwnerId, repoId = @Model.SelectedRepoId})">
+            <div id="loadingJobs">
+                @await Html.PartialAsync("_SpinnerPartial")
+            </div>
+        </div>
+    </div>
+    <div class="eight wide column">
+        <h3>Jobs</h3>
+        <div id="jobs" class="data-loader"
+             data-endpoint="@Url.RouteUrl("JobsLoader", new {ownerId = @Model.SelectedOwnerId, repoId = @Model.SelectedRepoId})">
+            <div id="loadingJobs">
+                @await Html.PartialAsync("_SpinnerPartial")
+            </div>
+        </div>
+    </div>
 </div>
 
 @section Scripts {
+    <environment names="Development">
+        <script src="~/lib/signalr/signalr.js"></script>
+    </environment>
+    <environment names="Staging,Production">
+        <script src="~/lib/signalr/signalr.min.js"></script>
+    </environment>
     <script type="text/javascript">
-        $(document).ready(function() { refresh() });
-
-        function refresh() {
-            $('.data-loader').each(function() {
-                var endpoint = $(this).data('endpoint');
-                var container = this;
-                $.ajax({
-                    type: "GET",
-                    url: endpoint
-                }).done(function(data) {
-                    $(container).html(data);
+        $(function () {
+            refreshAll();
+            var connection = new signalR.HubConnectionBuilder().withUrl('/progress')
+                .configureLogging(signalR.LogLevel.Information).build();
+            connection.on('datasetUpdated',
+                function(ownerId, repoId, datasetInfo) {
+                    console.log(ownerId, repoId, datasetInfo);
+                    refreshDatasets();
                 });
+            connection.on('datasetDeleted',
+                function (ownerId, repoId, datasetId) {
+                    console.log(ownerId, repoId, datasetId);
+                    refreshDatasets();
+                });
+            connection.on('sendMessage', function() {});
+            connection.on('statusUpdated', function(ownerId, jobId, jobStatus) {
+                console.log(ownerId, jobId, jobStatus);
+                setTimeout(refreshJobs, 2000);
             });
-            setTimeout(function() { refresh(); }, 5000);
+            connection.on('progressUpdated', function() {});
+            connection.start().then(() => {
+                @{
+                if (String.IsNullOrEmpty(Model.SelectedRepoId))
+                {
+                    <text>
+                        console.log('Subscribe to channel: @(Model.SelectedOwnerId)');
+                        connection.invoke('subscribe', '@(Model.SelectedOwnerId)');
+                    </text>
+                }
+                else
+                {
+                    <text>
+                        console.log('Subscribe to channel: @(Model.SelectedOwnerId)_@(Model.SelectedRepoId)');
+                        connection.invoke('subscribe', '@(Model.SelectedOwnerId)_@(Model.SelectedRepoId)');
+                    </text>
+                }
+            }
+
+            });
+
+        });
+
+        function refreshJobs() {
+            $('#jobs').each(function() { refreshContainer(this) });
+        }
+
+        function refreshDatasets() {
+            $('#datasets').each(function() { refreshContainer(this) });
+        }
+
+        function refreshAll() {
+            $('.data-loader').each(function() {
+                refreshContainer(this);
+            });
+        }
+
+        function refreshContainer(container) {
+            var endpoint = $(container).data('endpoint');
+            $.ajax({
+                type: "GET",
+                url: endpoint
+            }).done(function(data) {
+                $(container).html(data);
+            });
         }
     </script>
 }

--- a/src/DataDock.Web/Views/Shared/Dashboard/Jobs.cshtml
+++ b/src/DataDock.Web/Views/Shared/Dashboard/Jobs.cshtml
@@ -31,63 +31,87 @@
                 });
 
             connection.on('progressUpdated',
-                function (userId, jobId, progressMessage) {
-                    console.log(userId, jobId, progressMessage);
-                    var item = $('#' + jobId);
-                    if (!item) {
-                        console.log('Cannot find an element with that jobId');
+                function(ownerId, jobId, progressMessage) {
+                    console.log('progressUpdated', ownerId, jobId, progressMessage);
+                    if (ownerId === '@Model.SelectedOwnerId') {
+                        ensureJobEntry(jobId);
+                        var m = $('#' + jobId + ' > .processing-messages');
+                        m.removeClass('hidden')
+                            .append($('<div/>').html(progressMessage))
+                            .scrollTop(m.prop('scrollHeight'));
                     }
-                    var m = $('#' + jobId + ' > .processing-messages');
-                    m.removeClass('hidden')
-                        .append($('<div/>').html(progressMessage))
-                        .scrollTop(m.prop('scrollHeight'));
                 });
 
             connection.on('statusUpdated',
-                function(userId, jobId, jobStatus) {
-                    var item = $('#' + jobId);
-                    if (!item) {
-                        console.log('Cannot find an element with that jobId');
-                    }
-                    var statusText = getJobStatusText(jobStatus);
-                    $('#' + jobId + ' .job-status')
-                        .html(statusText);
-                    $('#' + jobId)
-                        .removeClass('positive negative info warning')
-                        .addClass(getJobStatusClass(jobStatus));
-                    if (statusText === "Failed" || statusText === "Completed") {
-                        var ll = $('#' + jobId + ' > .log-link');
-                        ll.removeClass('hidden');
-                        var m = $('#' + jobId + ' > .processing-messages');
-                        m.addClass('hidden');
+                function(ownerId, jobId, jobStatus) {
+                    console.log('statusUpdated', ownerId, jobId, jobStatus);
+                    if (ownerId === '@Model.SelectedOwnerId') {
+                        ensureJobEntry(jobId);
+                        var statusText = getJobStatusText(jobStatus);
+                        $('#' + jobId + ' .job-status')
+                            .html(statusText);
+                        $('#' + jobId)
+                            .removeClass('positive negative info warning')
+                            .addClass(getJobStatusClass(jobStatus));
+                        if (statusText === "Failed" || statusText === "Completed") {
+                            var ll = $('#' + jobId + ' > .log-link');
+                            ll.removeClass('hidden');
+                            var m = $('#' + jobId + ' > .processing-messages');
+                            m.addClass('hidden');
+                        }
                     }
                 });
 
-            connection.on('logUpdated',
-                function(userId, jobId, logLink) {
-                    var item = $('#' + jobId);
-                    if (!item) {
-                        console.log('Cannot find an element with that jobId');
-                    }
-                    $('#' + jobId + ' .log-link').append($("<a/>").attr('href', logLink).html('Download full log'));
-                    var dsUrl = $('#' + jobId + ' p#iri').text();
-                    var dsLink = $("<a />",
-                        {
-                            href: dsUrl,
-                            text: dsUrl,
-                            'style': 'font-weight:bold;'
-                        });
-                    $('#' + jobId + ' p#iri').text().append(dsLink);
+            connection.on('datasetUpdated',
+                function(ownerId, repoId, datasetInfo) {
+                    console.log('datasetUpdated', ownerId, repoId, datasetInfo);
                 });
+
+//            connection.on('logUpdated',
+//                function(ownerId, jobId, logLink) {
+//                    if (ownerId === '@Model.SelectedOwnerId') {
+//                        ensureJobEntry(jobId);
+//                        $('#' + jobId + ' .log-link').append($("<a/>").attr('href', logLink).html('Download full log'));
+//                        var dsUrl = $('#' + jobId + ' p#iri').text();
+//                        var dsLink = $("<a />",
+//                            {
+//                                href: dsUrl,
+//                                text: dsUrl,
+//                                'style': 'font-weight:bold;'
+//                            });
+//                        $('#' + jobId + ' p#iri').text().append(dsLink);
+//                    }
+//                });
 
             connection.start().then(() => {
                 console.log('ProgressHub Connected');
-                if('@Model.SelectedOwnerId' !== '@Model.UserId') { 
-                    console.log('Subscribe to channel: @Model.SelectedOwnerId');
-                    connection.invoke('subscribe', '@Model.SelectedOwnerId');
+                @{
+                    if (String.IsNullOrEmpty(Model.SelectedRepoId))
+                    {
+                        <text>
+                            console.log('Subscribe to channel: @(Model.SelectedOwnerId)');
+                            connection.invoke('subscribe', '@(Model.SelectedOwnerId)');
+                        </text>
+                    }
+                    else
+                    {
+                        <text>
+                            console.log('Subscribe to channel: @(Model.SelectedOwnerId)_@(Model.SelectedRepoId)');
+                            connection.invoke('subscribe', '@(Model.SelectedOwnerId)_@(Model.SelectedRepoId)');
+                        </text>
+                    }
                 }
             });
         });
+
+        function ensureJobEntry(jobId) {
+            var match = $('#' + jobId);
+            if (match.length === 0) {
+                console.log('No element found for ', jobId, 'Page will be reloaded');
+                document.location.reload(true);
+            }
+            return match;
+        }
 
         function htmlEncode(value) {
             var encodedValue = $('<div/>').text(value).html();

--- a/src/DataDock.Web/Views/Shared/Dashboard/Jobs.cshtml
+++ b/src/DataDock.Web/Views/Shared/Dashboard/Jobs.cshtml
@@ -11,111 +11,117 @@
 
 @section Scripts {
 
-  <environment names="Development">
-    <script src="~/lib/signalr/signalr.js"></script>
-  </environment>
-  <environment names="Staging,Production">
-    <script src="~/lib/signalr/signalr.min.js"></script>
-  </environment>
-  <script>
-    $(function () {
+    <environment names="Development">
+        <script src="~/lib/signalr/signalr.js"></script>
+    </environment>
+    <environment names="Staging,Production">
+        <script src="~/lib/signalr/signalr.min.js"></script>
+    </environment>
+    <script>
+        $(function() {
 
-      //var connection = new signalR.HubConnection('/progress');
-        var connection = new signalR.HubConnectionBuilder().withUrl('/progress')
-            .configureLogging(signalR.LogLevel.Information).build();
+            //var connection = new signalR.HubConnection('/progress');
+            var connection = new signalR.HubConnectionBuilder().withUrl('/progress')
+                .configureLogging(signalR.LogLevel.Information).build();
 
-      // Create a function that the hub can call to broadcast messages.
-      connection.on('sendMessage', function (userId, message) {
-        console.log(userId + ' ' + message);
-      });
+            // Create a function that the hub can call to broadcast messages.
+            connection.on('sendMessage',
+                function(userId, message) {
+                    console.log(userId + ' ' + message);
+                });
 
-      connection.on('progressUpdated',
-        function (userId, jobId, progressMessage) {
-          var item = $('#' + jobId);
-          if (!item) {
-            console.log('Cannot find an element with that jobId');
-          }
-          var m = $('#' + jobId + ' > .processing-messages');
-          m.removeClass('hidden')
-            .append($('<div/>').html(progressMessage))
-            .scrollTop(m.prop('scrollHeight'));
-        });
+            connection.on('progressUpdated',
+                function (userId, jobId, progressMessage) {
+                    console.log(userId, jobId, progressMessage);
+                    var item = $('#' + jobId);
+                    if (!item) {
+                        console.log('Cannot find an element with that jobId');
+                    }
+                    var m = $('#' + jobId + ' > .processing-messages');
+                    m.removeClass('hidden')
+                        .append($('<div/>').html(progressMessage))
+                        .scrollTop(m.prop('scrollHeight'));
+                });
 
-      connection.on('statusUpdated',
-        function (userId, jobId, jobStatus) {
-          var item = $('#' + jobId);
-          if (!item) {
-            console.log('Cannot find an element with that jobId');
-          }
-          var statusText = getJobStatusText(jobStatus);
-          $('#' + jobId + ' .job-status')
-            .html(statusText);
-          $('#' + jobId)
-            .removeClass('positive negative info warning')
-            .addClass(getJobStatusClass(jobStatus));
-          if (statusText === "Failed" || statusText === "Completed") {
-            var ll = $('#' + jobId + ' > .log-link');
-            ll.removeClass('hidden');
-            var m = $('#' + jobId + ' > .processing-messages');
-            m.addClass('hidden');
-          }
-        });
+            connection.on('statusUpdated',
+                function(userId, jobId, jobStatus) {
+                    var item = $('#' + jobId);
+                    if (!item) {
+                        console.log('Cannot find an element with that jobId');
+                    }
+                    var statusText = getJobStatusText(jobStatus);
+                    $('#' + jobId + ' .job-status')
+                        .html(statusText);
+                    $('#' + jobId)
+                        .removeClass('positive negative info warning')
+                        .addClass(getJobStatusClass(jobStatus));
+                    if (statusText === "Failed" || statusText === "Completed") {
+                        var ll = $('#' + jobId + ' > .log-link');
+                        ll.removeClass('hidden');
+                        var m = $('#' + jobId + ' > .processing-messages');
+                        m.addClass('hidden');
+                    }
+                });
 
-      connection.on('logUpdated',
-        function (userId, jobId, logLink) {
-          var item = $('#' + jobId);
-          if (!item) {
-            console.log('Cannot find an element with that jobId');
-          }
-          $('#' + jobId + ' .log-link').append($("<a/>").attr('href', logLink).html('Download full log'));
-          var dsUrl = $('#' + jobId + ' p#iri').text();
-          var dsLink = $("<a />",
-            {
-              href: dsUrl,
-              text: dsUrl,
-              'style': 'font-weight:bold;'
+            connection.on('logUpdated',
+                function(userId, jobId, logLink) {
+                    var item = $('#' + jobId);
+                    if (!item) {
+                        console.log('Cannot find an element with that jobId');
+                    }
+                    $('#' + jobId + ' .log-link').append($("<a/>").attr('href', logLink).html('Download full log'));
+                    var dsUrl = $('#' + jobId + ' p#iri').text();
+                    var dsLink = $("<a />",
+                        {
+                            href: dsUrl,
+                            text: dsUrl,
+                            'style': 'font-weight:bold;'
+                        });
+                    $('#' + jobId + ' p#iri').text().append(dsLink);
+                });
+
+            connection.start().then(() => {
+                console.log('ProgressHub Connected');
+                if('@Model.SelectedOwnerId' !== '@Model.UserId') { 
+                    console.log('Subscribe to channel: @Model.SelectedOwnerId');
+                    connection.invoke('subscribe', '@Model.SelectedOwnerId');
+                }
             });
-          $('#' + jobId + ' p#iri').text().append(dsLink);
         });
 
-      connection.start().then(() => {
-        console.log('ProgressHub Connected');
-      });
-    });
+        function htmlEncode(value) {
+            var encodedValue = $('<div/>').text(value).html();
+            return encodedValue;
+        }
 
-    function htmlEncode(value) {
-      var encodedValue = $('<div/>').text(value).html();
-      return encodedValue;
-    }
+        function getJobStatusText(statusCode) {
+            switch (statusCode) {
+            case 0:
+                return "Queued";
+            case 1:
+                return "Running";
+            case 2:
+                return "Completed";
+            case 3:
+                return "Failed";
+            default:
+                return "--";
+            }
+        }
 
-    function getJobStatusText(statusCode) {
-      switch (statusCode) {
-        case 0:
-          return "Queued";
-        case 1:
-          return "Running";
-        case 2:
-          return "Completed";
-        case 3:
-          return "Failed";
-        default:
-          return "--";
-      }
-    }
-
-    function getJobStatusClass(statusCode) {
-      switch (statusCode) {
-        case 0:
-          return "info";
-        case 1:
-          return "warning";
-        case 2:
-          return "positive";
-        case 3:
-          return "negative";
-        default:
-          return "info";
-      }
-    }
-  </script>
+        function getJobStatusClass(statusCode) {
+            switch (statusCode) {
+            case 0:
+                return "info";
+            case 1:
+                return "warning";
+            case 2:
+                return "positive";
+            case 3:
+                return "negative";
+            default:
+                return "info";
+            }
+        }
+    </script>
 }

--- a/src/DataDock.Worker.Tests/BaseDataDockRepositorySpec.cs
+++ b/src/DataDock.Worker.Tests/BaseDataDockRepositorySpec.cs
@@ -20,6 +20,7 @@ namespace DataDock.Worker.Tests
         protected readonly Mock<IFileGeneratorFactory> FileGeneratorFactory;
         protected readonly Mock<ITripleCollectionHandler> MockRdfFileGenerator;
         protected readonly Mock<IResourceStatementHandler> MockHtmlFileGenerator;
+        protected readonly MockProgressLog MockProgressLog;
 
         public BaseDataDockRepositorySpec()
         {
@@ -48,6 +49,7 @@ namespace DataDock.Worker.Tests
                     It.IsAny<int>(),
                     It.IsAny<Dictionary<string, object>>()))
                 .Returns(MockHtmlFileGenerator.Object);
+            MockProgressLog = new MockProgressLog();
 
             var uriService = new DataDockUriService("http://datadock.io/");
             BaseUri = new Uri("http://datadock.io/test/repo/");
@@ -56,7 +58,8 @@ namespace DataDock.Worker.Tests
             var htmlResourceMapper = new ResourceFileMapper(
                 new ResourceMapEntry(new Uri(BaseUri, "id"), "doc"));
 
-            Repo = new DataDockRepository(RepoPath, BaseUri, new MockProgressLog(),
+
+            Repo = new DataDockRepository(RepoPath, BaseUri, MockProgressLog,
                 quinceStoreFactory.Object, FileGeneratorFactory.Object,
                 rdfResourceMapper, htmlResourceMapper, uriService);
 

--- a/src/DataDock.Worker.Tests/MockProgressLog.cs
+++ b/src/DataDock.Worker.Tests/MockProgressLog.cs
@@ -19,6 +19,19 @@ namespace DataDock.Worker.Tests
             _builder.AppendFormat(progressMessage, args);
         }
 
+        public void DatasetUpdated(DatasetInfo datasetInfo)
+        {
+            Console.WriteLine("DatasetUpdated: {0}/{1}/{2}", datasetInfo.OwnerId, datasetInfo.RepositoryId, datasetInfo.DatasetId);
+            _builder.AppendFormat("DatasetUpdated: {0}/{1}/{2}", datasetInfo.OwnerId, datasetInfo.RepositoryId,
+                datasetInfo.DatasetId);
+        }
+
+        public void DatasetDeleted(string ownerId, string repoId, string datasetId)
+        {
+            Console.WriteLine("DatasetDeleted: {0}/{1}/{2}", ownerId, repoId, datasetId);
+            _builder.AppendFormat("DatasetDeleted: {0}/{1}/{2}", ownerId, repoId, datasetId);
+        }
+
         public void Info(string infoMessage, params object[] args)
         {
             Console.WriteLine("Info: " + infoMessage, args);

--- a/src/DataDock.Worker/IProgressLog.cs
+++ b/src/DataDock.Worker/IProgressLog.cs
@@ -13,6 +13,9 @@ namespace DataDock.Worker
         /// <param name="args"></param>
         void UpdateStatus(JobStatus newStatus, string progressMessage, params object[] args);
 
+        void DatasetUpdated(DatasetInfo datasetInfo);
+        void DatasetDeleted(string ownerId, string repoId, string datasetId);
+
         /// <summary>
         /// Log an informational message
         /// </summary>

--- a/src/DataDock.Worker/Processors/DeleteDatasetProcessor.cs
+++ b/src/DataDock.Worker/Processors/DeleteDatasetProcessor.cs
@@ -53,6 +53,7 @@ namespace DataDock.Worker.Processors
             {
                 await _git.PushChanges(jobInfo.GitRepositoryUrl, targetDirectory, authenticationToken);
             }
+
             try
             {
                 await _datasetStore.DeleteDatasetAsync(jobInfo.OwnerId, jobInfo.RepositoryId, jobInfo.DatasetId);
@@ -62,6 +63,10 @@ namespace DataDock.Worker.Processors
                 Log.Error(ex, "Failed to remove dataset record.");
                 throw new WorkerException(ex, "Failed to remove dataset record. Your repository is updated but the dataset may still show in the main lodlab portal");
             }
+
+            Log.Information("Dataset Deleted: {OwnerId}/RepositoryId/{DatasetId}",
+                jobInfo.OwnerId, jobInfo.RepositoryId, jobInfo.DatasetId);
+            progressLog.DatasetDeleted(jobInfo.OwnerId, jobInfo.RepositoryId, jobInfo.DatasetId);
 
         }
 

--- a/src/DataDock.Worker/Processors/ImportJobProcessor.cs
+++ b/src/DataDock.Worker/Processors/ImportJobProcessor.cs
@@ -162,7 +162,7 @@ namespace DataDock.Worker.Processors
             try
             {
                 var voidMetadataJson = ExtractVoidMetadata(metadataGraph);
-                await _datasetStore.CreateOrUpdateDatasetRecordAsync(new DatasetInfo
+                var datasetInfo = new DatasetInfo
                 {
                     OwnerId = job.OwnerId,
                     RepositoryId = job.RepositoryId,
@@ -172,15 +172,16 @@ namespace DataDock.Worker.Processors
                     VoidMetadata = voidMetadataJson,
                     ShowOnHomePage = job.IsPublic,
                     Tags = metadataJson["dcat:keyword"]?.ToObject<List<string>>()
-                });
+                };
+                await _datasetStore.CreateOrUpdateDatasetRecordAsync(datasetInfo);
+                _progressLog.DatasetUpdated(datasetInfo);
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to update dataset record");
                 throw new WorkerException(ex,
-                    "Failed to update dataset record. Your repository is updated, but may not show in the main lodlab portal.");
+                    "Failed to update dataset record. Your repository is updated, but may not show in the portal.");
             }
-
         }
 
         private async Task AddCsvFilesToRepository(string repositoryDirectory, string datasetId, string csvFileName, string csvFileId, string csvmFileId)

--- a/src/DataDock.Worker/SignalrProgressLog.cs
+++ b/src/DataDock.Worker/SignalrProgressLog.cs
@@ -24,8 +24,6 @@ namespace DataDock.Worker
             _fullLog = new StringBuilder();
         }
 
-       
-
 
         public void UpdateStatus(JobStatus newStatus, string progressMessage, params object[] args)
         {
@@ -109,7 +107,7 @@ namespace DataDock.Worker
             try
             {
                 
-                _hubConnection.InvokeAsync("StatusUpdated", _jobInfo.UserId, _jobInfo.JobId, jobStatus);
+                _hubConnection.InvokeAsync("StatusUpdated", _jobInfo.OwnerId, _jobInfo.JobId, jobStatus);
             }
             catch (Exception ex)
             {
@@ -121,11 +119,35 @@ namespace DataDock.Worker
         {
             try
             {
-                _hubConnection.InvokeAsync("ProgressUpdated", _jobInfo.UserId, _jobInfo.JobId, message);
+                _hubConnection.InvokeAsync("ProgressUpdated", _jobInfo.OwnerId, _jobInfo.JobId, message);
             }
             catch (Exception ex)
             {
                 _log.Error(ex, "Error notifying SignalR hub ProgressUpdated method");
+            }
+        }
+
+        public void DatasetUpdated(DatasetInfo datasetInfo)
+        {
+            try
+            {
+                _hubConnection.InvokeAsync("DatasetUpdated", datasetInfo.OwnerId, datasetInfo);
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Error notifying SignalR hub DatasetUpdated method");
+            }
+        }
+
+        public void DatasetDeleted(string ownerId, string repoId, string datasetId)
+        {
+            try
+            {
+                _hubConnection.InvokeAsync("DatasetDeleted", ownerId, repoId, datasetId);
+            }
+            catch (Exception ex)
+            {
+                _log.Error(ex, "Error notifying SignalR hub DatasetDeleted method");
             }
         }
     }

--- a/src/DataDock.Worker/SignalrProgressLog.cs
+++ b/src/DataDock.Worker/SignalrProgressLog.cs
@@ -107,7 +107,7 @@ namespace DataDock.Worker
             try
             {
                 
-                _hubConnection.InvokeAsync("StatusUpdated", _jobInfo.OwnerId, _jobInfo.JobId, jobStatus);
+                _hubConnection.InvokeAsync("StatusUpdated", _jobInfo.OwnerId, _jobInfo.RepositoryId, _jobInfo.JobId, jobStatus);
             }
             catch (Exception ex)
             {
@@ -119,7 +119,7 @@ namespace DataDock.Worker
         {
             try
             {
-                _hubConnection.InvokeAsync("ProgressUpdated", _jobInfo.OwnerId, _jobInfo.JobId, message);
+                _hubConnection.InvokeAsync("ProgressUpdated", _jobInfo.OwnerId, _jobInfo.RepositoryId, _jobInfo.JobId, message);
             }
             catch (Exception ex)
             {
@@ -131,7 +131,7 @@ namespace DataDock.Worker
         {
             try
             {
-                _hubConnection.InvokeAsync("DatasetUpdated", datasetInfo.OwnerId, datasetInfo);
+                _hubConnection.InvokeAsync("DatasetUpdated", datasetInfo.OwnerId, datasetInfo.RepositoryId, datasetInfo);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Added the ability to notify of dataset changes (new, updated and deleted datasets) via SignalR. Added a subscribe method that allows a client to subscribe to all messages relating to an owner or to messages relating to a specific repository of an owner.

Updated the datasets page and the dashboard page to use SignalR messages. These pages refresh only on receiving a SignalR message that indicates something new to display rather than automatically refreshing every 5 seconds. The refresh still requires a server round-trip however.

The jobs page continues to use SignalR messages, but has been updated to use the new subscribe functionality so that it only has to handle messages relating to the view currently being displayed.