### PR TITLE
Update handling of dataset id and aboutUrl when using a template

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ before_build:
   - sh: |
       dotnet restore src/DataDock.sln
       mono gitversion/GitVersion.exe /l console /output buildserver /updateassemblyinfo
-      export DockerImageVersion=$(mono gitversion/GitVersion.exe /output json /showVariable FullSemVer)
+      export DockerImageVersion=$(mono gitversion/GitVersion.exe /output json /showVariable FullSemVer | tr '+' '-')
       echo $DockerImageVersion
       npm install --global gulp-cli karma-cli
 

--- a/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
@@ -670,8 +670,10 @@
             _constructIdentifiersTabContent: function() {
                 var prefix = this._getPrefix();
                 var datasetId = this._slugify(this.options.filename, "", "", "camelCase");
-                var idFromFilename = prefix + "/id/dataset/" + datasetId;
-                var defaultValue = schemaHelper.getDatasetId(this.options.templateMetadata, idFromFilename);
+                // KA: If we do this, then the owner and repo from the template gets used in the new dataset id which is probably not what the user wants
+                // var idFromFilename = prefix + "/id/dataset/" + datasetId;
+                // var defaultValue = schemaHelper.getDatasetId(this.options.templateMetadata, idFromFilename);
+                var defaultValue = prefix + "/id/dataset/" + datasetId;
 
                 var dsIdTable = {
                     "type": "table",
@@ -744,6 +746,7 @@
                 var rowIdentifier = this._getIdentifierPrefix() + "/" + datasetId + "/row_{_row}";
                 var identifierOptions = {};
                 var columnCount = this.options.header.length;
+                var aboutUrl = schemaHelper.getAboutUrl(this.options.templateMetadata);
                 identifierOptions[rowIdentifier] = "Row Number";
 
                 for (var colIdx = 0; colIdx < columnCount; colIdx++) {
@@ -751,6 +754,10 @@
                     var colName = this._slugify(colTitle, "_", "_", "lowercase");
                     var colIdentifier = this._getIdentifierPrefix() + "/" + colName + "/{" + colName + "}";
                     identifierOptions[colIdentifier] = colTitle;
+                }
+
+                if (aboutUrl && !identifierOptions.hasOwnProperty(aboutUrl)) {
+                    identifierOptions[aboutUrl] = "Template pattern: " + aboutUrl;
                 }
                 identifierTableElements.push(
                     {

--- a/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
@@ -45,6 +45,10 @@
         return {};
     };
 
+    this.getAboutUrl = function(metadata) {
+        return getPropertyValue(metadata, "aboutUrl", null);
+    };
+
     this.getColumnTitle = function(colTemplate, defaultValue) {
         var titles = getPropertyValue(colTemplate, "titles", null);
         if (titles) {


### PR DESCRIPTION
The dataset id is no longer overridden by the template.
The aboutUrl is still overridden by the template, but the value in the template is now displayed so the user can review it and choose to select a different value if they want.
Fixes #109 