### PR TITLE
Use reverse proxy-aware OAuth handler

### DIFF
--- a/src/DataDock.Common.Tests/DirectoryLogStoreTests.cs
+++ b/src/DataDock.Common.Tests/DirectoryLogStoreTests.cs
@@ -80,7 +80,7 @@ namespace DataDock.Common.Tests
             var now = DateTime.UtcNow;
             timeProvider.SetupSequence(t => t.UtcNow)
                 .Returns(now.Subtract(TimeSpan.FromDays(89)))
-                .Returns(now.Subtract(TimeSpan.FromDays(89.9)))
+                .Returns(now.Subtract(TimeSpan.FromDays(90)))
                 .Returns(now.Subtract(TimeSpan.FromDays(91)))
                 .Returns(now);
 

--- a/src/DataDock.Common/Stores/DirectoryLogStore.cs
+++ b/src/DataDock.Common/Stores/DirectoryLogStore.cs
@@ -75,12 +75,13 @@ namespace DataDock.Common.Stores
         {
             _log.Information("PruneLogs Started");
             var today = _timeProvider.UtcNow;
+                DateTimeKind.Utc);
             foreach (var dir in Directory.EnumerateDirectories(_basePath))
             {
                 _log.Debug("PruneLog evaluated directory {LogDir}", dir);
                 var dirDate = DateTime.ParseExact(Path.GetFileName(dir), "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
                 _log.Debug("PruneLog evaluated log directory date as {DirDate} for {LogDir}", dirDate, dir );
-                var dirAge = Math.Floor(today.Subtract(dirDate).TotalDays);
+                var dirAge = Math.Floor(today.Date.Subtract(dirDate).TotalDays);
                 if (dirAge > LogTimeToLive)
                 {
                     try

--- a/src/DataDock.Common/Stores/DirectoryLogStore.cs
+++ b/src/DataDock.Common/Stores/DirectoryLogStore.cs
@@ -75,7 +75,6 @@ namespace DataDock.Common.Stores
         {
             _log.Information("PruneLogs Started");
             var today = _timeProvider.UtcNow;
-                DateTimeKind.Utc);
             foreach (var dir in Directory.EnumerateDirectories(_basePath))
             {
                 _log.Debug("PruneLog evaluated directory {LogDir}", dir);

--- a/src/DataDock.Web/Startup.cs
+++ b/src/DataDock.Web/Startup.cs
@@ -116,7 +116,7 @@ namespace DataDock.Web
                     options.LogoutPath = new PathString("/account/logoff/");
                     options.AccessDeniedPath = "/account/forbidden/";
                 })
-                .AddOAuth("GitHub", options =>
+                .AddReverseProxyOAuth("GitHub", options =>
                 {
                     options.ClientId = config.OAuthClientId;
                     options.ClientSecret = config.OAuthClientSecret;


### PR DESCRIPTION
Change to the startup to use the previously created OAuth handler that uses X-Forwarded-Host and X-Forwarded-Proto headers to create the OAuth callback URL. This should enable the client to generate an HTTPS callback URL when the HTTPS termination is handled by a reverse proxy.