### PR TITLE
Use relative IRIs in templates

### DIFF
--- a/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
@@ -59,7 +59,8 @@
                 });
             },
 
-            loadSchema: function(onLoad) {
+            loadSchema: function (onLoad) {
+                var self = this;
                 if (this.options.schemaId) {
                     var options = {
                         url: "/api/schemas",
@@ -72,6 +73,8 @@
                             console.log("Template returned from DataDock schema API");
                             console.log(response);
                             if (response["schema"] && response["schema"]["metadata"]) {
+                                schemaHelper.makeAbsolute(response.schema.metadata,
+                                    self.options.publishUrl + "/" + self.options.ownerId + "/" + self.options.repoId + "/");
                                 onLoad({
                                     success: true,
                                     schemaTitle: response["schema"]["dc:title"] || "",

--- a/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
@@ -68,5 +68,27 @@
     this.getColumnSuppressed = function(colTemplate) {
         return getPropertyValue(colTemplate, "suppressOutput", false);
     }
+    
+    this.makeAbsolute = function (tok, baseUri) {
+        if (Array.isArray(tok)) {
+            tok.forEach((item) => { schemaHelper.makeAbsolute(item, baseUri) });
+        } else if (typeof (tok) === "object" && tok !== null) {
+            Object.keys(tok).forEach((k) => {
+                if (tok.hasOwnProperty(k)) {
+                    if (k === "aboutUrl" ||
+                        k === "propertyUrl" ||
+                        k === "valueUrl") {
+                        if (!tok[k].includes("://")) {
+                            tok[k] = baseUri + tok[k];
+                        }
+                    } else {
+                        if (tok[k] != null && (Array.isArray(tok[k]) || typeof(tok[k]) === "object")) {
+                            schemaHelper.makeAbsolute(tok[k], baseUri);
+                        }
+                    }
+                }
+            });
+        }
+    }
 
 }).apply(schemaHelper);

--- a/src/DataDock.Web/wwwroot/js/tests/schemahelper.spec.js
+++ b/src/DataDock.Web/wwwroot/js/tests/schemahelper.spec.js
@@ -138,5 +138,60 @@
                     expect(schemaHelper.getColumnSuppressed(col)).toBe(false);
                 });
         });
-        
+
+    describe("makeAbsolute",
+        function() {
+            it("updates a top level aboutUrl property",
+                function() {
+                    var schema = { "aboutUrl": "some/relative/path" };
+                    schemaHelper.makeAbsolute(schema, "http://datadock.io/foo/bar/");
+                    expect(schema.aboutUrl).toBe("http://datadock.io/foo/bar/some/relative/path");
+                });
+            it("updates a nested aboutUrl property",
+                function() {
+                    var schema = { "metadata": { "aboutUrl": "some/relative/path" } };
+                    schemaHelper.makeAbsolute(schema, "http://datadock.io/foo/bar/");
+                    expect(schema.metadata.aboutUrl).toBe("http://datadock.io/foo/bar/some/relative/path");
+                });
+            it("updates a propertyUrl in a nested array",
+                function() {
+                    var schema = {
+                        "metadata": {
+                            "tableSchema": {
+                                "columns": [
+                                    {
+                                        "name": "colName",
+                                        "propertyUrl": "id/definition/colName",
+                                        "datatype": "string"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                    schemaHelper.makeAbsolute(schema, "http://datadock.io/foo/bar/");
+                    expect(schema.metadata.tableSchema.columns[0].propertyUrl)
+                        .toBe("http://datadock.io/foo/bar/id/definition/colName");
+                });
+            it("updates a valueUrl in a nested array and does not update an absolute propertyUrl",
+                function() {
+                    var schema = {
+                        "metadata": {
+                            "tableSchema": {
+                                "columns": [
+                                    {
+                                        "name": "colName",
+                                        "propertyUrl": "http://example.org/foo",
+                                        "valueUrl": "id/resource/widget/{colName}"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                    schemaHelper.makeAbsolute(schema, "http://datadock.io/foo/bar/");
+                    expect(schema.metadata.tableSchema.columns[0].propertyUrl)
+                        .toBe("http://example.org/foo");
+                    expect(schema.metadata.tableSchema.columns[0].valueUrl)
+                        .toBe("http://datadock.io/foo/bar/id/resource/widget/{colName}");
+                });
+        });
 });

--- a/src/DataDock.Worker.Tests/ImportSchemeProcessorSpec.cs
+++ b/src/DataDock.Worker.Tests/ImportSchemeProcessorSpec.cs
@@ -81,15 +81,15 @@ namespace DataDock.Worker.Tests
             };
             await proc.ProcessJob(job, new UserAccount(), _mockProgressLog.Object);
             _mockSchemeStore.Verify(s=>s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p=>
-                (p.Schema["aboutUrl"] as JValue).Value<string>().Equals("/id/resource/mydataset/monument_record_no/{monument_record_no}"))));
+                (p.Schema["aboutUrl"] as JValue).Value<string>().Equals("id/resource/mydataset/monument_record_no/{monument_record_no}"))));
             _mockSchemeStore.Verify(s => s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p =>
                 (p.Schema["dc:title"] as JValue).Value<string>().Equals("http://datadock.io/datadock/test/foo"))));
             _mockSchemeStore.Verify(s => s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p =>
                 (p.Schema["tableSchema"]["columns"][0]["propertyUrl"] as JValue).Value<string>()
-                .Equals("/id/definition/foo"))));
+                .Equals("id/definition/foo"))));
             _mockSchemeStore.Verify(s => s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p =>
                 (p.Schema["tableSchema"]["columns"][0]["valueUrl"] as JValue).Value<string>()
-                .Equals("/id/bar/{bar}"))));
+                .Equals("id/bar/{bar}"))));
         }
     }
 }

--- a/src/DataDock.Worker.Tests/ImportSchemeProcessorSpec.cs
+++ b/src/DataDock.Worker.Tests/ImportSchemeProcessorSpec.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using DataDock.Common.Models;
+using DataDock.Common.Stores;
+using DataDock.Worker.Processors;
+using Moq;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace DataDock.Worker.Tests
+{
+    public class ImportSchemeProcessorSpec
+    {
+        private readonly Mock<ISchemaStore> _mockSchemeStore;
+        private readonly Mock<IFileStore> _mockFileStore;
+        private readonly Mock<IProgressLog> _mockProgressLog;
+
+        public ImportSchemeProcessorSpec()
+        {
+            _mockSchemeStore = new Mock<ISchemaStore>();
+            _mockFileStore = new Mock<IFileStore>();
+            _mockProgressLog = new Mock<IProgressLog>();
+        }
+
+        private void WithJsonSchema(string jsonString)
+        {
+            _mockFileStore.Setup(fs => fs.GetFileAsync(It.IsAny<string>()))
+                .ReturnsAsync(() => new MemoryStream(Encoding.UTF8.GetBytes(jsonString)));
+        }
+
+        [Fact]
+        public async void ItWrapsTheSchemaInSourceMetadata()
+        {
+            var config = new WorkerConfiguration { PublishUrl = "http://datadock.io/" };
+            var proc = new ImportSchemaProcessor(config, _mockSchemeStore.Object, _mockFileStore.Object);
+            WithJsonSchema(@"{ '@context': 'http://www.w3.org/ns/csvw' }");
+            var job = new JobInfo
+            {
+                JobType = JobType.SchemaCreate,
+                UserId = "kal",
+                OwnerId = "datadock",
+                RepositoryId = "test",
+                SchemaFileId = "schemaFileId"
+            };
+            await proc.ProcessJob(job, new UserAccount(), _mockProgressLog.Object);
+            _mockSchemeStore.Verify(s => s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p =>
+                p.OwnerId.Equals("datadock") &&
+                p.RepositoryId.Equals("test") &&
+                p.Schema.ContainsKey("@context") &&
+                (p.Schema["@context"] as JValue).Value<string>().Equals("http://www.w3.org/ns/csvw"))));
+        }
+
+        [Fact]
+        public async Task ItMakesUrlPropertiesRelative()
+        {
+            var config = new WorkerConfiguration {PublishUrl = "http://datadock.io/"};
+            var proc = new ImportSchemaProcessor(config, _mockSchemeStore.Object, _mockFileStore.Object);
+            WithJsonSchema(@"{
+                '@context': 'http://www.w3.org/ns/csvw',
+                'url': 'http://datadock.io/datadock/test/id/dataset/mydataset',
+                'dc:title': 'http://datadock.io/datadock/test/foo',
+                'dc:license': 'https://creativecommons.org/publicdomain/zero/1.0/',
+                'aboutUrl': 'http://datadock.io/datadock/test/id/resource/mydataset/monument_record_no/{monument_record_no}', 
+                'tableSchema': {
+                    'columns': [
+                        {
+                            'name' : 'foo',
+                            'propertyUrl': 'http://datadock.io/datadock/test/id/definition/foo',
+                            'valueUrl' : 'http://datadock.io/datadock/test/id/bar/{bar}'
+                        }
+                    ]
+                }
+            }");
+            var job = new JobInfo
+            {
+                JobType = JobType.SchemaCreate, UserId = "kal", OwnerId = "datadock", RepositoryId = "test",
+                SchemaFileId = "schemaFileId"
+            };
+            await proc.ProcessJob(job, new UserAccount(), _mockProgressLog.Object);
+            _mockSchemeStore.Verify(s=>s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p=>
+                (p.Schema["aboutUrl"] as JValue).Value<string>().Equals("/id/resource/mydataset/monument_record_no/{monument_record_no}"))));
+            _mockSchemeStore.Verify(s => s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p =>
+                (p.Schema["dc:title"] as JValue).Value<string>().Equals("http://datadock.io/datadock/test/foo"))));
+            _mockSchemeStore.Verify(s => s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p =>
+                (p.Schema["tableSchema"]["columns"][0]["propertyUrl"] as JValue).Value<string>()
+                .Equals("/id/definition/foo"))));
+            _mockSchemeStore.Verify(s => s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p =>
+                (p.Schema["tableSchema"]["columns"][0]["valueUrl"] as JValue).Value<string>()
+                .Equals("/id/bar/{bar}"))));
+        }
+    }
+}

--- a/src/DataDock.Worker/Application.cs
+++ b/src/DataDock.Worker/Application.cs
@@ -84,7 +84,10 @@ namespace DataDock.Worker
                         break;
                     }
                     case JobType.SchemaCreate:
-                        processor = new ImportSchemaProcessor(Services.GetRequiredService<ISchemaStore>(), Services.GetRequiredService<IFileStore>());
+                        processor = new ImportSchemaProcessor(
+                            Services.GetRequiredService<WorkerConfiguration>(), 
+                            Services.GetRequiredService<ISchemaStore>(), 
+                            Services.GetRequiredService<IFileStore>());
                         break;
                     case JobType.SchemaDelete:
                         processor = new DeleteSchemaProcessor(Services.GetRequiredService<ISchemaStore>());

--- a/src/DataDock.Worker/Processors/ImportSchemaProcessor.cs
+++ b/src/DataDock.Worker/Processors/ImportSchemaProcessor.cs
@@ -51,7 +51,7 @@ namespace DataDock.Worker.Processors
                         _progressLog.UpdateStatus(JobStatus.Running, "Retrieved DataDock schema file.");
 
                         MakeRelative(schemaJson,
-                            $"{_configuration.PublishUrl}{(_configuration.PublishUrl.EndsWith("/") ? string.Empty : "/")}{job.OwnerId}/{job.RepositoryId}");
+                            $"{_configuration.PublishUrl}{(_configuration.PublishUrl.EndsWith("/") ? string.Empty : "/")}{job.OwnerId}/{job.RepositoryId}/");
 
                         Log.Debug("Create schema: OwnerId: {ownerId} RepositoryId: {repoId} SchemaFileId: {schemaFileId}",
                             job.OwnerId, job.RepositoryId, job.SchemaFileId);

--- a/src/DataDock.Worker/Processors/ImportSchemaProcessor.cs
+++ b/src/DataDock.Worker/Processors/ImportSchemaProcessor.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using DataDock.Common.Models;
 using DataDock.Common.Stores;
+using Nest;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Serilog;
@@ -13,12 +14,14 @@ namespace DataDock.Worker.Processors
     {
         private readonly ISchemaStore _schemaStore;
         private readonly IFileStore _jobFileStore;
+        private readonly WorkerConfiguration _configuration;
         private IProgressLog _progressLog;
 
-        public ImportSchemaProcessor(ISchemaStore schemaStore, IFileStore jobFileStore)
+        public ImportSchemaProcessor(WorkerConfiguration configuration, ISchemaStore schemaStore, IFileStore jobFileStore)
         {
             _schemaStore = schemaStore;
             _jobFileStore = jobFileStore;
+            _configuration = configuration;
         }
 
         public async Task ProcessJob(JobInfo job, UserAccount userAccount, IProgressLog progressLog)
@@ -46,6 +49,9 @@ namespace DataDock.Worker.Processors
                     if (schemaJson != null)
                     {
                         _progressLog.UpdateStatus(JobStatus.Running, "Retrieved DataDock schema file.");
+
+                        MakeRelative(schemaJson,
+                            $"{_configuration.PublishUrl}{(_configuration.PublishUrl.EndsWith("/") ? string.Empty : "/")}{job.OwnerId}/{job.RepositoryId}");
 
                         Log.Debug("Create schema: OwnerId: {ownerId} RepositoryId: {repoId} SchemaFileId: {schemaFileId}",
                             job.OwnerId, job.RepositoryId, job.SchemaFileId);
@@ -84,6 +90,40 @@ namespace DataDock.Worker.Processors
 
                 throw new WorkerException(ex,
                     "Failed to update schema record.");
+            }
+        }
+
+        private void MakeRelative(JToken tok, string baseUri)
+        {
+            switch (tok)
+            {
+                case JObject o:
+                {
+                    foreach (var p in o.Properties())
+                    {
+                        if (p.Name.Equals("aboutUrl") ||
+                            p.Name.Equals("propertyUrl") ||
+                            p.Name.Equals("valueUrl"))
+                        {
+                            if (p.Value.Type == JTokenType.String &&
+                                p.Value.Value<string>().StartsWith(baseUri))
+                            {
+                                p.Value = p.Value.Value<string>().Substring(baseUri.Length);
+                            }
+                        }
+                        if (p.Value.Type == JTokenType.Array || p.Value.Type == JTokenType.Object)
+                        {
+                            MakeRelative(p.Value, baseUri);
+                        }
+                    }
+
+                    break;
+                }
+                case JArray a:
+                {
+                    foreach (var item in a) MakeRelative(item, baseUri);
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Changed the schema create job so that it converts absolute URLs in the schema (in aboutUrl, propertyUrl and valueUrl) into relative URLs relative to {publishUrl}/{ownerId}/{repoId}/.
Changed the metadata editor to convert relative URLs back to absolute URLs when a schema is loaded from a template, using the target owner and repo id for the import.

Fixes #126