### PR TITLE
Minor dashboard improvements

### DIFF
--- a/src/DataDock.Web/ViewModels/JobHistoryViewModel.cs
+++ b/src/DataDock.Web/ViewModels/JobHistoryViewModel.cs
@@ -36,6 +36,7 @@ namespace DataDock.Web.ViewModels
         public string OwnerId => _jobInfo.OwnerId;
         public string RepositoryId => _jobInfo.RepositoryId;
         public string DatasetIri => _jobInfo.DatasetIri;
+        public string UserId => _jobInfo.UserId;
         public string CurrentStatus => _jobInfo.CurrentStatus.ToString();
         public DateTime CompletedAt => _jobInfo.CompletedAt;
         public DateTime StartedAt => _jobInfo.StartedAt;

--- a/src/DataDock.Web/Views/Shared/Components/Datasets/Default.cshtml
+++ b/src/DataDock.Web/Views/Shared/Components/Datasets/Default.cshtml
@@ -4,7 +4,7 @@
 @if (Model != null && Model.Count > 0)
 {
 
-  <div class="ui segments">
+  <div class="ui one cards">
     @foreach (var ds in Model)
     {
       var datasetVisible = ds.ShowOnHomePage.HasValue && ds.ShowOnHomePage.Value;
@@ -22,10 +22,11 @@
             </div>
           </div>
           <div class="header">@ds.GetTitle()</div>
-          <div class="meta">Last Modified: @ds.LastModified.ToString("d", CultureInfo.CurrentUICulture)</div>
-          <div class="description">
-            <p>@ds.GetDescription()</p>
-          </div>
+            <div class="meta">Last Modified: @ds.LastModified.ToString("d", CultureInfo.CurrentUICulture)</div>
+            @if (!string.IsNullOrEmpty(ds.GetDescription()))
+            {
+                <div class="description"><p>@ds.GetDescription()</p></div>
+            }
         </div>
         <div class="extra content">
           <div class="meta">@ds.GetIri()</div>

--- a/src/DataDock.Web/Views/Shared/Components/JobHistory/Default.cshtml
+++ b/src/DataDock.Web/Views/Shared/Components/JobHistory/Default.cshtml
@@ -2,43 +2,47 @@
 
 @if (Model != null && Model.Count > 0)
 {
-    
-  <div class="ui segments">
-    @foreach (var job in Model)
-    {
-      var logAvailable = !string.IsNullOrEmpty(job.LogId);
-      <div class="ui attached @job.StatusClass message" id="@job.JobId">
-        <div class="ui header">@job.JobType - <span class="job-status"> @job.CurrentStatus </span></div>
-        <div class="content">
-          <p>
-            <strong>@job.DatasetIri</strong>
-          </p>
-            <div class="meta">
-                @if (job.QueuedAt.Year > 2000)
-                {
-                    <span>Queued At: @job.QueuedAt</span>
-                }
-                @if (job.StartedAt.Year > 2000)
-                {
-                     <span>Started At: @job.StartedAt</span>
-                }
-                @if (job.CompletedAt.Year > 2000)
-                {
-                    <span>Completed At: @job.CompletedAt</span>
-                }
+    <div class="ui segments">
+        @foreach (var job in Model)
+        {
+            <div class="ui attached @job.StatusClass message" id="@job.JobId">
+                <div class="ui header">
+                    <img class="ui image" src="https://github.com/@(job.UserId).png?size=64" width="32" height="32" title="Job started by @job.UserId" alt="@job.UserId"/>
+                    <div class="content">
+                        @job.JobType started by @job.UserId <br/>
+                        <span class="job-status"> @job.CurrentStatus </span>
+                    </div>
+                </div>
+                <div class="content" style="padding-top: 1ex">
+                    <div>
+                        <strong>@job.DatasetIri</strong>
+                    </div>
+                    <div class="meta">
+                        @if (job.CompletedAt.Year > 2000)
+                        {
+                            <span>Completed At: @job.CompletedAt</span>
+                        }
+                        else if (job.StartedAt.Year > 2000)
+                        {
+                            <span>Started At: @job.StartedAt</span>
+                        }
+                        else if (job.QueuedAt.Year > 2000)
+                        {
+                            <span>Queued At: @job.QueuedAt</span>
+                        }
+                    </div>
+                </div>
+                <div class="processing-messages hidden"></div>
+                <div class="extra content log-link @(string.IsNullOrEmpty(job.LogId) ? "hidden" : "")">
+                    <a href="@Url.RouteUrl("JobLog", new {ownerId = job.OwnerId, repoId = job.RepositoryId, jobId = job.JobId})">View Full Log</a>
+                </div>
             </div>
-        </div>
-        <div class="processing-messages hidden"></div>
-        <div class="extra content log-link @(string.IsNullOrEmpty(job.LogId) ? "hidden" : "")">
-          <a href="@Url.RouteUrl("JobLog", new {ownerId=job.OwnerId, repoId=job.RepositoryId, jobId=job.JobId})">View Full Log</a>
-        </div>
-      </div>
-    }
-  </div>
+        }
+    </div>
 }
 else
 {
-  <div class="ui warning message">
-    None found.
-  </div>
+    <div class="ui warning message">
+        None found.
+    </div>
 }

--- a/src/DataDock.Web/Views/Shared/Dashboard/Index.cshtml
+++ b/src/DataDock.Web/Views/Shared/Dashboard/Index.cshtml
@@ -4,8 +4,8 @@
     Model.Title = Model.Title + " Summary";
 }
 
-<div class="ui grid">
-    <div class="eight wide column">
+<div class="ui stackable two column grid">
+    <div class="column">
         <h3>Datasets</h3>
         <div id="datasets" class="data-loader"
              data-endpoint="@Url.RouteUrl("DatasetsLoader", new {ownerId = @Model.SelectedOwnerId, repoId = @Model.SelectedRepoId})">
@@ -14,7 +14,7 @@
             </div>
         </div>
     </div>
-    <div class="eight wide column">
+    <div class="column">
         <h3>Jobs</h3>
         <div id="jobs" class="data-loader"
              data-endpoint="@Url.RouteUrl("JobsLoader", new {ownerId = @Model.SelectedOwnerId, repoId = @Model.SelectedRepoId})">

--- a/src/DataDock.Web/wwwroot/css/site.css
+++ b/src/DataDock.Web/wwwroot/css/site.css
@@ -375,3 +375,7 @@ pre.rawJson {
     white-space: -o-pre-wrap; /* Opera 7 */
     word-wrap: break-word; /* Internet Explorer 5.5+ */
 }
+
+#jobs .ui.message .content {
+    overflow:visible !important;
+}


### PR DESCRIPTION
- Include the avatar and name of the user who started the job in the jobs list.
- Make job display a bit more compact and readable by only displaying either completed, started or queued date for each job rather than all three
- Make dataset cards a bit more compact by omitting the <p> for description if there is no description and removing additional padding whitespace around the <p>
- Make dashboard columns stack on mobile/narrow displays.