### PR TITLE
Fix data portal page not displaying top level contents

### DIFF
--- a/src/DataDock.Web/Api/DataController.cs
+++ b/src/DataDock.Web/Api/DataController.cs
@@ -102,6 +102,19 @@ namespace DataDock.Web.Api
                         "Repository does not exist or you do not have the required authorization to publish to it.");
                 }
 
+                // create a settings record for the owner if one does not already exist
+                try
+                {
+                    var ownerSettings = await _importService.CheckOwnerSettingsAsync(User, jobRequest.OwnerId);
+                }
+                catch (Exception e)
+                {
+                    Log.Error(
+                        $"api/data: unable to retrive ownerSettings for the supplied owner '{jobRequest.OwnerId}'");
+                    return BadRequest(
+                        "The user or organization does not exist or you do not have the required authorization to publish to it.");
+                }
+
                 var job = await _jobStore.SubmitImportJobAsync(jobRequest);
                 
                 Log.Information("api/data(POST): Conversion job started.");

--- a/src/DataDock.Web/Controllers/LinkedDataController.cs
+++ b/src/DataDock.Web/Controllers/LinkedDataController.cs
@@ -41,23 +41,30 @@ namespace DataDock.Web.Controllers
             {
                 return RedirectToAction("Index", "Home");
             }
-            var ownerSettings = await _ownerSettingsStore.GetOwnerSettingsAsync(ownerId);
 
-            var portalViewModel = new PortalViewModel(ownerSettings);
-            
-
-            // repos
             try
             {
-                var repos = await _repoSettingsStore.GetRepoSettingsForOwnerAsync(ownerId);
-                portalViewModel.RepoIds = repos.Select(r => r.RepositoryId).ToList();
+                var ownerSettings = await _ownerSettingsStore.GetOwnerSettingsAsync(ownerId);
+                var portalViewModel = new PortalViewModel(ownerSettings);
+                
+                // repos
+                try
+                {
+                    var repos = await _repoSettingsStore.GetRepoSettingsForOwnerAsync(ownerId);
+                    portalViewModel.RepoIds = repos.Select(r => r.RepositoryId).ToList();
+                }
+                catch (Exception e)
+                {
+                    Log.Error(e, "Error getting repositories for {0}", ownerId);
+                }
+
+                return View("Index", portalViewModel);
             }
-            catch (Exception e)
+            catch (OwnerSettingsNotFoundException osnf)
             {
-                Log.Error(e, "Error getting repositories for {0}", ownerId);
+                //redirect to a friendly warning page
+                return View("OwnerNotFound");
             }
-            
-            return View("Index", portalViewModel); ;
         }
 
         /// <summary>

--- a/src/DataDock.Web/DataDock.Web.csproj
+++ b/src/DataDock.Web/DataDock.Web.csproj
@@ -31,6 +31,9 @@
     <Content Update="Views\Info\Temp.cshtml">
       <Pack>$(IncludeRazorContentInPack)</Pack>
     </Content>
+    <Content Update="Views\LinkedData\OwnerNotFound.cshtml">
+      <Pack>$(IncludeRazorContentInPack)</Pack>
+    </Content>
     <Content Update="Views\LinkedData\Index.cshtml">
       <Pack>$(IncludeRazorContentInPack)</Pack>
     </Content>

--- a/src/DataDock.Web/Services/IImportService.cs
+++ b/src/DataDock.Web/Services/IImportService.cs
@@ -7,6 +7,7 @@ namespace DataDock.Web.Services
 {
     public interface IImportService
     {
+        Task<OwnerSettings> CheckOwnerSettingsAsync(ClaimsPrincipal user, string ownerId);
         Task<RepoSettings> CheckRepoSettingsAsync(ClaimsPrincipal user, string ownerId, string repoId);
         Task<bool> CheckUserIsAdminOfOwner(ClaimsPrincipal user, string ownerId);
     }

--- a/src/DataDock.Web/Views/LinkedData/OwnerNotFound.cshtml
+++ b/src/DataDock.Web/Views/LinkedData/OwnerNotFound.cshtml
@@ -1,0 +1,19 @@
+@{
+    ViewData["Title"] = "Error";
+}
+
+<h1 class="text-warning">Portal Not Found.</h1>
+<h2 class="text-warning">DataDock was unable to find a portal with that owner ID</h2>
+
+
+
+<p>We were unable to find a portal with that Owner ID, the reasons you might see this page are:
+  <ul>
+    <li>The owner has not set up the portal settings page to allow you to view the top level portal contents page</li>
+    <li>The owner has discontinued or changed their user or organization name</li>
+    <li>You have mistyped the web address, or followed a broken link</li>
+  </ul></p>
+
+<p>Good luck in your hunt for data!</p>
+
+<p>If you think you're seeing this page due to a problem with the DataDock platform, you can raise an issue on the <a href="https://github.com/DataDock/datadock/issues" title="DataDock on GitHub">DataDock issues list</a>.</p>


### PR DESCRIPTION
Error page when DD could not find an owner settings record.
- auto-create a blank owner settings record (if needed) when publishing
new data
- display a friendly warning page if no owner settings record found
(instead of error message)

fixes #142