### PR TITLE
Fix routing and display of datasets when hiding/showing them

### DIFF
--- a/src/DataDock.Web/Controllers/RepositoryController.cs
+++ b/src/DataDock.Web/Controllers/RepositoryController.cs
@@ -57,23 +57,6 @@ namespace DataDock.Web.Controllers
         }
 
         /// <summary>
-        /// View the details of a particular dataset
-        /// </summary>
-        /// <param name="ownerId">Dataset owner</param>
-        /// <param name="repoId">Dataset repository</param>
-        /// <param name="datasetId">Dataset ID</param>
-        /// <returns></returns>
-        public IActionResult Dataset(string ownerId, string repoId, string datasetId)
-        {
-            DashboardViewModel.Area = "datasets";
-            DashboardViewModel.Heading = "Dataset";
-            DashboardViewModel.SelectedDatasetId = datasetId;
-            DashboardViewModel.Title = string.Format("{0} > {1} > {2}", DashboardViewModel.SelectedOwnerId,
-                DashboardViewModel.SelectedRepoId, datasetId);
-            return View("Dashboard/Dataset", this.DashboardViewModel);
-        }
-
-        /// <summary>
         /// User or Org template library for a partcular repo
         /// Viewable by authorized users only
         /// </summary>

--- a/src/DataDock.Web/Startup.cs
+++ b/src/DataDock.Web/Startup.cs
@@ -372,7 +372,7 @@ namespace DataDock.Web
                 routes.MapRoute(
                     name: "Dataset",
                     template: "dashboard/datasets/{ownerId}/{repoId}/{datasetId}",
-                    defaults: new { controller = "Repository", action = "Dataset" },
+                    defaults: new { controller = "Dataset", action = "Index" },
                     constraints: new { ownerId = new OwnerIdConstraint(), repoId = new RepoIdConstraint() }
                 );
                 routes.MapRoute(


### PR DESCRIPTION
The action to update visibility now redirects the browser back to the dataset index route after performing the update. The route used is now using the Index action of the DatasetController which is a bit more logical than the Dataset action on the RepositoryController (which has now been removed).