### PR TITLE
Add support for creating nodes and for language codes

### DIFF
--- a/src/DataDock.Web/Services/DefaultImportFormParser.cs
+++ b/src/DataDock.Web/Services/DefaultImportFormParser.cs
@@ -160,6 +160,7 @@ namespace DataDock.Web.Services
             var metadataStream = new MemoryStream(byteArray);
             var csvwFileId = await _fileStore.AddFileAsync(metadataStream);
             jobInfo.CsvmFileId = csvwFileId;
+            jobInfo.OverwriteExistingData = formData.OverwriteExisting;
 
             if (formData.SaveAsSchema)
             {

--- a/src/DataDock.Web/editor_test.html
+++ b/src/DataDock.Web/editor_test.html
@@ -1,0 +1,82 @@
+﻿<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Metadata Editor Test</title>
+    <link rel="stylesheet" href="wwwroot/semantic-ui/dist/semantic.css"/>
+    <link rel="stylesheet" href="wwwroot/css/site.css"/>
+    <link rel="stylesheet" href="wwwroot/css/inputosaurus.css"/>
+    <link rel="stylesheet" href="wwwroot/css/spinner.css"/>
+</head> 
+<body>
+    
+<div id="validation-container">
+<!-- Validation Messages -->
+<div class="ui negative message validation-messages" id="validation-messages" style="display: none;">
+</div>
+    
+</div>
+<div id="errors">
+    <div class="ui negative message" id="error-messages" style="display: none;">
+
+    </div>    
+</div>
+<div class="ui hidden divider"></div>
+<div class="ui container">
+    <div id="metadataEditor">
+        <form class="ui form" id="metadataEditorForm"></form>
+    </div>
+</div>
+<script src="https://code.jquery.com/jquery-3.3.1.js"
+        integrity="sha256-2Kok7MbOyxpgUVvAk/HJ2jigOSYS2auK4Pfzbm7uH60="
+        crossorigin="anonymous"></script>
+<script
+    src="http://code.jquery.com/ui/1.12.1/jquery-ui.js"
+    integrity="sha256-T0Vest3yCU7pafRw9r+settMBX6JkKN06dqBnpQ8d30="
+    crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.3.1/semantic.min.js" type="text/javascript"></script>
+<script>
+    $(document)
+        .ready(function () {
+
+            var csvData = [
+                ["Column A", "Column B", "Column C"],
+                ["A1", "B1", "C1"],
+                ["A2", "B2", "C2"]
+            ];
+            // create sidebar and attach to menu open
+            $('.ui.sidebar').sidebar('attach events', '.toc.item');
+            $('.ui.accordion').accordion();
+            $('#metadataEditor').metadataEditor({
+                baseUrl: "http://datadock.io",
+                publishUrl: "http://datadock.io",
+                ownerId: "owner",
+                repoId: "repo",
+                schemaId: null,
+                apiUrl: null,
+                csvData: csvData,
+                header: csvData[0],
+                filename: "test.csv",
+                schemaTitle: null,
+                templateMetadata: null
+            }).bind("metadataeditorsubmit",
+                function(ev, data) {
+                    console.log(data);
+                });
+        });
+
+</script>
+
+<environment names="Development">
+    <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.17.0/dist/jquery.validate.min.js" type="text/javascript"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.17.0/dist/additional-methods.min.js" type="text/javascript"></script>
+    <script src="wwwroot/js/jquery.dform-1.1.0.js"></script>
+    <script src="wwwroot/js/datadock.portal.js"></script>
+    <script src="wwwroot/js/datadock.schemahelper.js"></script>
+    <script src="wwwroot/js/datadock.metadataeditor.js"></script>
+    <script src="wwwroot/js/datadock.datatypeSniffer.js"></script>
+    <script src="wwwroot/lib/momentjs/moment.js"></script>
+    <script src="wwwroot/js/inputosaurus.js"></script>
+</environment>
+</body>
+</html>

--- a/src/DataDock.Web/editor_test.html
+++ b/src/DataDock.Web/editor_test.html
@@ -65,7 +65,8 @@
                                 "stop"
                             ],
                             "datatype": "string",
-                            "propertyUrl": "http://www.w3.org/2000/01/rdf-schema#label"
+                            "propertyUrl": "http://www.w3.org/2000/01/rdf-schema#label",
+                            "lang": "en-GB"
                         },
                         {
                             "name": "seealso",
@@ -80,6 +81,7 @@
                             "titles": [
                                 "at_station"
                             ],
+                            "aboutUrl": "{seealso}",
                             "valueUrl": "id/resource/station/{at_station}",
                             "propertyUrl": "id/definition/at_station"
                         },

--- a/src/DataDock.Web/editor_test.html
+++ b/src/DataDock.Web/editor_test.html
@@ -40,10 +40,61 @@
         .ready(function () {
 
             var csvData = [
-                ["Column A", "Column B", "Column C"],
-                ["A1", "B1", "C1"],
-                ["A2", "B2", "C2"]
+                ["stop", "seeAlso", "at_station", "on_line"],
+                ["A1", "B1", "C1", "D1"],
+                ["A2", "B2", "C2", "D2"]
             ];
+
+            var metadata = {
+                "@context": "http://www.w3.org/ns/csvw",
+                "url": "http://datadock.io/kal/local_data/id/dataset/tokyoMetroStops",
+                "dc:title": "Tokyo Metro Stops",
+                "dc:description": "",
+                "dcat:keyword": [
+                    "tokyo",
+                    "metro",
+                    "transport"
+                ],
+                "dc:license": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "aboutUrl": "id/resource/stop/{stop}",
+                "tableSchema": {
+                    "columns": [
+                        {
+                            "name": "stop",
+                            "titles": [
+                                "stop"
+                            ],
+                            "datatype": "string",
+                            "propertyUrl": "http://www.w3.org/2000/01/rdf-schema#label"
+                        },
+                        {
+                            "name": "seealso",
+                            "titles": [
+                                "﻿seeAlso"
+                            ],
+                            "valueUrl": "{seealso}",
+                            "propertyUrl": "http://www.w3.org/1999/02/22-rdf-syntax-ns#seeAlso"
+                        },
+                        {
+                            "name": "at_station",
+                            "titles": [
+                                "at_station"
+                            ],
+                            "valueUrl": "id/resource/station/{at_station}",
+                            "propertyUrl": "id/definition/at_station"
+                        },
+                        {
+                            "name": "on_line",
+                            "titles": [
+                                "on_line"
+                            ],
+                            "valueUrl": "id/resource/line/{on_line}",
+                            "propertyUrl": "id/definition/on_line"
+                        }
+                    ]
+                }
+            };
+            schemaHelper.makeAbsolute(metadata, "http://datadock.io/owner/repo/");
             // create sidebar and attach to menu open
             $('.ui.sidebar').sidebar('attach events', '.toc.item');
             $('.ui.accordion').accordion();
@@ -57,8 +108,8 @@
                 csvData: csvData,
                 header: csvData[0],
                 filename: "test.csv",
-                schemaTitle: null,
-                templateMetadata: null
+                schemaTitle: "Test Schema",
+                templateMetadata: metadata
             }).bind("metadataeditorsubmit",
                 function(ev, data) {
                     console.log(data);

--- a/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
@@ -170,6 +170,7 @@
                 formData.append("showOnHomePage", JSON.stringify(editorData.showOnHomePage));
                 formData.append("saveAsSchema", JSON.stringify(editorData.saveAsSchema));
                 formData.append("addToExisting", JSON.stringify(editorData.addToExisting));
+                formData.append("overwriteExisting", JSON.stringify(!editorData.addToExisting));
 
                 var apiOptions = {
                     url: "/api/data",
@@ -1072,11 +1073,30 @@
                             }
                         ]
                     };
+
+                    var languageField = {
+                        type: "div",
+                        class: "field datatype-field datatype-string",
+                        html: [
+                            {
+                                type: "label",
+                                html: "Language",
+                                for: colName + "_lang"
+                            },
+                            {
+                                name: colName + "_lang",
+                                id: colName + "_lang",
+                                type: "text",
+                                placeholder: "e.g. en, fr, de-AT"
+                            }
+                        ]
+                    };
+
                     var predDiv = {
                         "type": "div",
                         "class": "field",
                         id: colName + "_advanced",
-                        "html": [parentField, predicateField, uriTemplateField]
+                        "html": [parentField, predicateField, uriTemplateField, languageField]
                     };
                     var tdPredicate = { "type": "td", "html": predDiv };
                     trElements.push(tdPredicate);
@@ -1307,6 +1327,7 @@
                         var colName = this.columnSet[i];
                         var colTemplate = schemaHelper.getColumnTemplate(this.options.templateMetadata, colName);
                         var colDatatype = schemaHelper.getColumnDatatype(colTemplate, "");
+                        var colLang = schemaHelper.getColumnLang(colTemplate, "");
                         var selector = $("#" + colName + "_datatype");
                         if (colDatatype) {
                             if (selector) {
@@ -1329,6 +1350,9 @@
                             if (parentColumn) {
                                 $('#' + colName + '_parent').val(parentColumn);
                             }
+                        }
+                        if (colLang) {
+                            $('#' + colName + '_lang').val(colLang);
                         }
                         this._updateDatatype(colName, selector.val());
                     }
@@ -1429,6 +1453,12 @@
                         column["valueUrl"] = "{" + columnName + "}";
                     } else {
                         column["datatype"] = $(colId + "_datatype").val();
+                    }
+                    if (datatype === "string") {
+                        var lang = $(colId + "_lang").val();
+                        if (lang) {
+                            column["lang"] = lang;
+                        }
                     }
                     column["propertyUrl"] = $(colId + "_property_url").val();
                 }

--- a/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
@@ -91,6 +91,10 @@
     this.getColumnSuppressed = function(colTemplate) {
         return getPropertyValue(colTemplate, "suppressOutput", false);
     }
+
+    this.getColumnLang = function(colTemplate, defaultValue) {
+        return getPropertyValue(colTemplate, "lang", defaultValue);
+    }
     
     this.makeAbsolute = function (tok, baseUri) {
         if (Array.isArray(tok)) {

--- a/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
@@ -45,6 +45,21 @@
         return {};
     };
 
+    this.getColumnWithValueUrl = function(metadata, valueUrl) {
+        var tableSchema = getPropertyValue(metadata, "tableSchema", null);
+        if (tableSchema) {
+            var columns = getPropertyValue(tableSchema, "columns", null);
+            if (columns) {
+                for (var i = 0; i < columns.length; i++) {
+                    if (Object.hasOwnProperty(columns[i], "valueUrl") && columns[i]["valueUrl"] === valueUrl) {
+                        return columns[i]["name"];
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     this.getAboutUrl = function(metadata) {
         return getPropertyValue(metadata, "aboutUrl", null);
     };
@@ -57,12 +72,20 @@
         return defaultValue;
     }
 
+    this.getColumnAboutUrl = function(colTemplate, defaultValue) {
+        return getPropertyValue(colTemplate, "aboutUrl", defaultValue);
+    }
+
     this.getColumnPropertyUrl = function(colTemplate, defaultValue) {
         return getPropertyValue(colTemplate, "propertyUrl", defaultValue);
     }
 
     this.getColumnDatatype = function(colTemplate, defaultValue) {
         return getPropertyValue(colTemplate, "datatype", defaultValue);
+    }
+
+    this.getColumnValueUrl = function(colTemplate, defaultValue) {
+        return getPropertyValue(colTemplate, "valueUrl", defaultValue);
     }
 
     this.getColumnSuppressed = function(colTemplate) {
@@ -78,7 +101,7 @@
                     if (k === "aboutUrl" ||
                         k === "propertyUrl" ||
                         k === "valueUrl") {
-                        if (!tok[k].includes("://")) {
+                        if (!tok[k].includes("://") && !/^\{[^\}]+\}$/.test(tok[k])) {
                             tok[k] = baseUri + tok[k];
                         }
                     } else {

--- a/src/DataDock.Worker/DataDock.Worker.csproj
+++ b/src/DataDock.Worker/DataDock.Worker.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DataDock.Common\DataDock.Common.csproj" />
-    <PackageReference Include="DataDock.CsvWeb" Version="0.1.0-pre0002" />
+    <PackageReference Include="DataDock.CsvWeb" Version="0.1.0-pre0003" />
     <PackageReference Include="DotLiquid" Version="2.0.298" />
     <PackageReference Include="dotNetRDF" Version="2.1.0" />
     <PackageReference Include="Elasticsearch.Net" Version="6.4.0" />

--- a/src/DataDock.Worker/Processors/ImportJobProcessor.cs
+++ b/src/DataDock.Worker/Processors/ImportJobProcessor.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using DataDock.Common.Models;
 using DataDock.Common.Stores;
 using DataDock.Common;
+using DataDock.CsvWeb;
 using DataDock.CsvWeb.Metadata;
 using DataDock.CsvWeb.Parsing;
 using DataDock.CsvWeb.Rdf;
@@ -98,10 +99,9 @@ namespace DataDock.Worker.Processors
                 var header = tmpReader.ReadLine();
                 Log.Information("CSV header: {CsvHeader}",header);
             }
-            using (var csvReader = File.OpenText(csvPath))
-            {
-                datasetGraph = GenerateDatasetGraph(csvReader, metadataJson);
-            }
+
+            var metadataBaseUri = new Uri(datasetUri + "/csv/" + job.CsvFileName + "-metadata.json");
+            datasetGraph = await GenerateDatasetGraphAsync(csvPath, metadataJson, metadataBaseUri);
             IGraph metadataGraph = GenerateMetadataGraph(datasetUri, publisherIri, metadataJson,
                 new[] { ntriplesDownloadLink, csvDownloadLink }, datasetGraph);
 
@@ -226,13 +226,13 @@ namespace DataDock.Worker.Processors
 
         }
 
-        private Graph GenerateDatasetGraph(TextReader csvReader, JObject metadataJson)
+        private async Task<Graph> GenerateDatasetGraphAsync(string csvPath, JObject metadataJson, Uri metadataUri)
         {
-            var parser = new JsonMetadataParser(null);
-            Table tableMeta;
+            var parser = new JsonMetadataParser(null, metadataUri);
+            var tableGroup = new TableGroup();
             try
             {
-                tableMeta = parser.Parse(metadataJson) as Table;
+                var tableMeta = parser.ParseTable(tableGroup, metadataJson);
                 if (tableMeta == null)
                 {
                     throw new WorkerException("CSV Conversion failed. Unable to read CSV table metadata.");
@@ -247,8 +247,9 @@ namespace DataDock.Worker.Processors
             var graph = new Graph();
             ProgressLog.Info("Running CSV to RDF conversion");
             var graphHandler = new GraphHandler(graph);
-            var converter = new Converter(tableMeta, graphHandler, (msg) => ProgressLog.Error(msg), this, reportInterval: CsvConversionReportInterval);
-            converter.Convert(csvReader);
+            var tableResolver = new LocalTableResolver(tableGroup.Tables[0].Url, csvPath);
+            var converter = new Converter(graphHandler, tableResolver, ConverterMode.Minimal, (msg) => ProgressLog.Error(msg), this, reportInterval: CsvConversionReportInterval);
+            await converter.ConvertAsync(tableGroup);
             if (converter.Errors.Any())
             {
                 foreach (var e in converter.Errors)
@@ -324,5 +325,27 @@ namespace DataDock.Worker.Processors
         }
     }
 
+    internal class LocalTableResolver:ITableResolver
+    {
+        private readonly Dictionary<Uri, string> _lookup = new Dictionary<Uri, string>();
+        public LocalTableResolver(Uri csvUri, string csvFilePath)
+        {
+            _lookup[csvUri] = csvFilePath;
+        }
 
+        public async Task<Stream> ResolveAsync(Uri tableUri)
+        {
+            if (_lookup.TryGetValue(tableUri, out string filePath))
+            {
+                return File.OpenRead(filePath);
+            }
+
+            throw new FileNotFoundException("Could not resolve URI " + tableUri);
+        }
+
+        public Task<JObject> ResolveJsonAsync(Uri jsonUri)
+        {
+            throw new NotImplementedException();
+        }
+    }
 }


### PR DESCRIPTION
- Added a new URI template field type that allows non-URI values to be turned into URIs. The template can be set on the Advanced tab
- When URI or URI Template is set as the datatype for a column, that column can now be selected as the parent of another column on the Advanced tab
- When Text (string) is set as the datatype for a column, a language code for that column can now be set on the Advanced tab
- Fixed a bug where datasets were not being overwritten by default on import.