### PR TITLE
Make the column ID column collapse

### DIFF
--- a/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.metadataeditor.js
@@ -875,18 +875,10 @@
                             {
                                 "type": "tr",
                                 "html": [
-                                    {
-                                        "type": "th",
-                                        "html": "Title"
-                                    },
-                                    {
-                                        "type": "th",
-                                        "html": "DataType"
-                                    },
-                                    {
-                                        "type": "th",
-                                        "html": "Suppress In Output"
-                                    }
+                                    { "type": "th", "html": "Column", "class": "collapsing" },
+                                    { "type": "th", "html": "Title" },
+                                    { "type": "th", "html": "DataType" },
+                                    { "type": "th", "html": "Suppress In Output", "class": "collapsing" }
                                 ]
                             }
                         ]
@@ -902,6 +894,7 @@
 
                     this.columnSet.push(colName);
 
+                    trElements.push({ "type": "td", "html": colName, "class": "collapsing" });
                     var colTemplate = schemaHelper.getColumnTemplate(this.options.templateMetadata, colName);
                     var defaultTitleValue = schemaHelper.getColumnTitle(colTemplate, colTitle);
                     var titleField = {
@@ -975,6 +968,7 @@
                                 "html": [
                                     {
                                         "type": "th",
+                                        "class": "collapsing",
                                         "html": "Column"
                                     },
                                     {
@@ -997,7 +991,11 @@
                         type: "div",
                         html: colTitle
                     };
-                    var tdTitle = { "type": "td", "html": titleDiv };
+                    var tdTitle = {
+                        "type": "td",
+                        "class": "collapsing",
+                        "html": titleDiv
+                    };
                     trElements.push(tdTitle);
 
                     var predicate = this._getPrefix() + "/id/definition/" + colName;


### PR DESCRIPTION
Gives more space for the Advanced Configuration column on the Advanced tab.
Added a Column col to the Column Definitions tab so that it is more consistent with the Advanced Tab and users can see that column ID and column Title are separate things.