### PR TITLE
Update dependencies

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,23 +11,21 @@ services:
   - docker
 
 install:
-  - wget https://github.com/GitTools/GitVersion/releases/download/v4.0.0/GitVersion-bin-net40-v4.0.0.zip
-  - unzip -d gitversion GitVersion-bin-net40-v4.0.0.zip
+  - wget https://github.com/GitTools/GitVersion/releases/download/5.1.1/gitversion-linux-5.1.1.tar.gz
+  - tar -zxf gitversion-linux-5.1.1.tar.gz
   - sh: nvm install $nodejs_version
 
 before_build:
   - sh: |
       dotnet restore src/DataDock.sln
-      mono gitversion/GitVersion.exe /l console /output buildserver /updateassemblyinfo
-      export DockerImageVersion=$(mono gitversion/GitVersion.exe /output json /showVariable FullSemVer | tr '+' '-')
-      echo $DockerImageVersion
+      GitVersion/GitVersion /l console /output buildserver /updateassemblyinfo
       npm install --global gulp-cli karma-cli
 
 configuration: Release
 
 build_script:
   - sh: dotnet build -c Release src/DataDock.sln
-  - sh: msbuild /t:BuildImages /p:Tag=$DockerImageVersion build.proj 
+  - sh: msbuild /t:BuildImages /p:Tag=$GitVersion_FullSemVer build.proj 
 
 test_script:
   - dotnet test -c Release src/DataDock.Common.Tests
@@ -41,14 +39,14 @@ deploy_script:
   - sh: |
       if [ "$APPVEYOR_REPO_TAG" == "true" ]; then
         docker login -u=$DOCKER_USER -p=$DOCKER_PASS
-        docker push datadock/web:$DockerImageVersion
+        docker push datadock/web:$GitVersion_FullSemVer
         docker push datadock/web:latest
-        docker push datadock/worker:$DockerImageVersion
+        docker push datadock/worker:$GitVersion_FullSemVer
         docker push datadock/worker:latest
       elif [ "$APPVEYOR_REPO_BRANCH" == "develop" ]; then
         docker login -u=$DOCKER_USER -p=$DOCKER_PASS
-        docker push datadock/web:$DockerImageVersion
-        docker push datadock/worker:$DockerImageVersion
+        docker push datadock/web:$GitVersion_FullSemVer
+        docker push datadock/worker:$GitVersion_FullSemVer
       else
         echo "Deployment will only run on a tag or commit to master"
       fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,8 @@ before_build:
 configuration: Release
 
 build_script:
-  - dotnet build -c Release src/DataDock.sln
-  - msbuild /t:BuildImages /p:Tag=$DockerImageVersion build.proj 
+  - sh: dotnet build -c Release src/DataDock.sln
+  - sh: msbuild /t:BuildImages /p:Tag=$DockerImageVersion build.proj 
 
 test_script:
   - dotnet test -c Release src/DataDock.Common.Tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,16 +18,15 @@ install:
 before_build:
   - sh: |
       dotnet restore src/DataDock.sln
-      GitVersion /l console /output buildserver
-      echo GitVersion Full: $GitVersion_FullSemVer
-      echo GitVersion NuGet: $GitVersion_NuGetVersion
+      export DockerImageVersion=$(GitVersion /output json /showVariable FullSemVer | tr '+' '-')
+      echo GitVersion : $DockerImageVersion
       npm install --global gulp-cli karma-cli
 
 configuration: Release
 
 build_script:
   - sh: dotnet build -c Release src/DataDock.sln
-  - sh: msbuild /t:BuildImages /p:Tag=$GitVersion_FullSemVer build.proj 
+  - sh: msbuild /t:BuildImages /p:Tag=$DockerImageVersion build.proj 
 
 test_script:
   - dotnet test -c Release src/DataDock.Common.Tests
@@ -41,14 +40,14 @@ deploy_script:
   - sh: |
       if [ "$APPVEYOR_REPO_TAG" == "true" ]; then
         docker login -u=$DOCKER_USER -p=$DOCKER_PASS
-        docker push datadock/web:$GitVersion_FullSemVer
+        docker push datadock/web:$DockerImageVersion
         docker push datadock/web:latest
-        docker push datadock/worker:$GitVersion_FullSemVer
+        docker push datadock/worker:$DockerImageVersion
         docker push datadock/worker:latest
       elif [ "$APPVEYOR_REPO_BRANCH" == "develop" ]; then
         docker login -u=$DOCKER_USER -p=$DOCKER_PASS
-        docker push datadock/web:$GitVersion_FullSemVer
-        docker push datadock/worker:$GitVersion_FullSemVer
+        docker push datadock/web:$DockerImageVersion
+        docker push datadock/worker:$DockerImageVersion
       else
         echo "Deployment will only run on a tag or commit to master"
       fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
 before_build:
   - sh: |
       dotnet restore src/DataDock.sln
-      GitVersion/GitVersion /l console /output buildserver
+      GitVersion /l console /output buildserver
       echo GitVersion Full: $GitVersion_FullSemVer
       echo GitVersion NuGet: $GitVersion_NuGetVersion
       npm install --global gulp-cli karma-cli

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,9 @@ install:
 before_build:
   - sh: |
       dotnet restore src/DataDock.sln
-      GitVersion/GitVersion /l console /output buildserver /updateassemblyinfo
+      GitVersion/GitVersion /l console /output buildserver
+      echo GitVersion Full: $GitVersion_FullSemVer
+      echo GitVersion NuGet: $GitVersion_NuGetVersion
       npm install --global gulp-cli karma-cli
 
 configuration: Release

--- a/src/DataDock.Common.Tests/DataDock.Common.Tests.csproj
+++ b/src/DataDock.Common.Tests/DataDock.Common.Tests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/DataDock.Common.Tests/DirectoryLogStoreTests.cs
+++ b/src/DataDock.Common.Tests/DirectoryLogStoreTests.cs
@@ -81,7 +81,7 @@ namespace DataDock.Common.Tests
             timeProvider.SetupSequence(t => t.UtcNow)
                 .Returns(now.Subtract(TimeSpan.FromDays(89)))
                 .Returns(now.Subtract(TimeSpan.FromDays(90)))
-                .Returns(now.Subtract(TimeSpan.FromDays(91)))
+                .Returns(now.Subtract(TimeSpan.FromDays(92))) // KA: Note that using 91 as a test case will fail intermittently depending on the time when the test is run
                 .Returns(now);
 
             var job1Id = Guid.NewGuid().ToString("N");

--- a/src/DataDock.Common/DataDock.Common.csproj
+++ b/src/DataDock.Common/DataDock.Common.csproj
@@ -5,13 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="8.1.3" />
+    <PackageReference Include="FluentValidation" Version="8.6.1" />
     <PackageReference Include="NEST" Version="6.8.3" />
     <PackageReference Include="NEST.JsonNetSerializer" Version="6.8.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Octokit" Version="0.32.0" />
-    <PackageReference Include="Polly" Version="7.1.0" />
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Octokit" Version="0.36.0" />
+    <PackageReference Include="Polly" Version="7.2.0" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/DataDock.Common/DataDock.Common.csproj
+++ b/src/DataDock.Common/DataDock.Common.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.1.3" />
-    <PackageReference Include="NEST" Version="6.5.1" />
-    <PackageReference Include="NEST.JsonNetSerializer" Version="6.5.1" />
+    <PackageReference Include="NEST" Version="6.8.3" />
+    <PackageReference Include="NEST.JsonNetSerializer" Version="6.8.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Polly" Version="7.1.0" />

--- a/src/DataDock.Common/ElasticClientExtensions.cs
+++ b/src/DataDock.Common/ElasticClientExtensions.cs
@@ -12,7 +12,7 @@ namespace DataDock.Common
     {
         public static void WaitForInitialization(this IElasticClient client)
         {
-            var retry = Policy.HandleResult(false)
+            var retry = Polly.Policy.HandleResult(false)
                 .WaitAndRetryForever(retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
                     (result, timespan) =>
                     {

--- a/src/DataDock.IntegrationTests/DataDock.IntegrationTests.csproj
+++ b/src/DataDock.IntegrationTests/DataDock.IntegrationTests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/DataDock.Web.Tests/DataDock.Web.Tests.csproj
+++ b/src/DataDock.Web.Tests/DataDock.Web.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="WireMock.Net" Version="1.0.8" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/src/DataDock.Web/DataDock.Web.csproj
+++ b/src/DataDock.Web/DataDock.Web.csproj
@@ -9,13 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Chutzpah" Version="4.4.4" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="8.1.3" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="8.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.2.3" />
-    <PackageReference Include="Octokit" Version="0.32.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+    <PackageReference Include="Octokit" Version="0.36.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="7.1.0" />
   </ItemGroup>
 

--- a/src/DataDock.Worker.Tests/DataDock.Worker.Tests.csproj
+++ b/src/DataDock.Worker.Tests/DataDock.Worker.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dotNetRDF" Version="2.2.0" />
-    <PackageReference Include="FluentAssertions" Version="5.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="dotNetRDF" Version="2.4.0-pre0004" />
+    <PackageReference Include="FluentAssertions" Version="5.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/DataDock.Worker.Tests/NQuadFormatterSpec.cs
+++ b/src/DataDock.Worker.Tests/NQuadFormatterSpec.cs
@@ -26,7 +26,7 @@ namespace DataDock.Worker.Tests
 
             quad.Should()
                 .Be(
-                    "<http://example.org/foo\\u0020bar> <http://example.org/p> \"some string\" <http://example.org/g>.");
+                    "<http://example.org/foo%20bar> <http://example.org/p> \"some string\" <http://example.org/g>.");
         }
     }
 }

--- a/src/DataDock.Worker/DataDock.Worker.csproj
+++ b/src/DataDock.Worker/DataDock.Worker.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="DataDock.CsvWeb" Version="0.1.0-pre0003" />
     <PackageReference Include="DotLiquid" Version="2.0.298" />
     <PackageReference Include="dotNetRDF" Version="2.2.0" />
-    <PackageReference Include="Elasticsearch.Net" Version="6.5.1" />
+    <PackageReference Include="Elasticsearch.Net" Version="6.8.3" />
     <PackageReference Include="MedallionShell" Version="1.5.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />

--- a/src/DataDock.Worker/DataDock.Worker.csproj
+++ b/src/DataDock.Worker/DataDock.Worker.csproj
@@ -7,18 +7,18 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DataDock.Common\DataDock.Common.csproj" />
-    <PackageReference Include="DataDock.CsvWeb" Version="0.1.0-pre0003" />
-    <PackageReference Include="DotLiquid" Version="2.0.298" />
-    <PackageReference Include="dotNetRDF" Version="2.2.0" />
+    <PackageReference Include="DataDock.CsvWeb" Version="0.1.0-pre0005" />
+    <PackageReference Include="DotLiquid" Version="2.0.314" />
+    <PackageReference Include="dotNetRDF" Version="2.4.0-pre0004" />
     <PackageReference Include="Elasticsearch.Net" Version="6.8.3" />
-    <PackageReference Include="MedallionShell" Version="1.5.1" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.1.0" />
+    <PackageReference Include="MedallionShell" Version="1.6.1" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Octokit" Version="0.32.0" />
-    <PackageReference Include="Polly" Version="7.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
+    <PackageReference Include="Octokit" Version="0.36.0" />
+    <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Quince" Version="0.5.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="7.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Elasticsearch libraries are only updated to latest 6.x as 7.x libraries won't support the 6.x Elasticsearch server we currently have in the docker configuration for the service.