### PR TITLE
Fix column datatype update plus new features

### DIFF
--- a/src/DataDock.Common.Tests/DataDock.Common.Tests.csproj
+++ b/src/DataDock.Common.Tests/DataDock.Common.Tests.csproj
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/DataDock.ImportUI/public/index.html
+++ b/src/DataDock.ImportUI/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <link rel="icon" href="favicon.ico">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css">
     <title>template-editor</title>
   </head>
@@ -19,7 +19,7 @@
       data-publish-url="http://datadock.io"
       data-base-url="http://localhost:5000"
       data-api-url="http://localhost:5000/api"
-      data-schema-id="ed3ee9be-a4a4-4fcf-8488-1bce7b75bcfd"
+      data-schema-id-x="ed3ee9be-a4a4-4fcf-8488-1bce7b75bcfd"
     ></div>
     <!-- built files will be auto injected -->
     </div>

--- a/src/DataDock.ImportUI/public/index.html
+++ b/src/DataDock.ImportUI/public/index.html
@@ -19,7 +19,7 @@
       data-publish-url="http://datadock.io"
       data-base-url="http://localhost:5000"
       data-api-url="http://localhost:5000/api"
-      data-schema-id-x="ed3ee9be-a4a4-4fcf-8488-1bce7b75bcfd"
+      data-schema-id-x="f929ad02-5eeb-4e66-9fc7-0f820ba015bf"
     ></div>
     <!-- built files will be auto injected -->
     </div>

--- a/src/DataDock.ImportUI/src/App.vue
+++ b/src/DataDock.ImportUI/src/App.vue
@@ -186,7 +186,6 @@ export default class App extends Vue {
       "/";
     this.makeAbsolute(templateMetadata, baseUri);
     this.ensureColumnDatatype(templateMetadata);
-    console.log(templateMetadata);
     return templateMetadata;
   }
 

--- a/src/DataDock.ImportUI/src/App.vue
+++ b/src/DataDock.ImportUI/src/App.vue
@@ -168,6 +168,7 @@ export default class App extends Vue {
         propertyUrl: this.identifierBase + "/definition/" + colId
       });
     }
+    this.ensureColumnDatatype(templateMetadata);
     return templateMetadata;
   }
 
@@ -184,7 +185,16 @@ export default class App extends Vue {
       this.$root.$data.repoId +
       "/";
     this.makeAbsolute(templateMetadata, baseUri);
+    this.ensureColumnDatatype(templateMetadata);
     return templateMetadata;
+  }
+
+  ensureColumnDatatype(templateMetadata: any) {
+    for (let i = 0; i < templateMetadata.tableSchema.columns.length; i++) {
+      templateMetadata.tableSchema.columns[i] = Helper.addSchemaDatatype(
+        templateMetadata.tableSchema.columns[i]
+      );
+    }
   }
 
   readonly colRefRegExp: RegExp = /^\{[^}]+\}$/;

--- a/src/DataDock.ImportUI/src/App.vue
+++ b/src/DataDock.ImportUI/src/App.vue
@@ -186,6 +186,7 @@ export default class App extends Vue {
       "/";
     this.makeAbsolute(templateMetadata, baseUri);
     this.ensureColumnDatatype(templateMetadata);
+    console.log(templateMetadata);
     return templateMetadata;
   }
 

--- a/src/DataDock.ImportUI/src/DataDock.ts
+++ b/src/DataDock.ImportUI/src/DataDock.ts
@@ -12,9 +12,12 @@ export class Helper {
         columnSchema.valueUrl.startsWith("{") &&
         columnSchema.valueUrl.endsWith("}")
       ) {
-        return Object.assign({}, columnSchema, { valueUrl: "uri" });
+        return Object.assign({}, columnSchema, { datatype: "uri" });
       } else {
-        return Object.assign({}, columnSchema, { valueUrl: "uriTemplate" });
+        console.log("Change ", columnSchema.name, "to uriTemplate");
+        var ret = Object.assign({}, columnSchema, { datatype: "uriTemplate" });
+        console.log(ret);
+        return ret;
       }
     }
     return columnSchema;

--- a/src/DataDock.ImportUI/src/DataDock.ts
+++ b/src/DataDock.ImportUI/src/DataDock.ts
@@ -5,6 +5,45 @@ export class Helper {
   public static slugify(original: string) {
     return _.camelCase(_.deburr(_.trim(original)));
   }
+
+  public static addSchemaDatatype(columnSchema: any): any {
+    if ("valueUrl" in columnSchema) {
+      if (
+        columnSchema.valueUrl.startsWith("{") &&
+        columnSchema.valueUrl.endsWith("}")
+      ) {
+        return Object.assign({}, columnSchema, { valueUrl: "uri" });
+      } else {
+        return Object.assign({}, columnSchema, { valueUrl: "uriTemplate" });
+      }
+    }
+    return columnSchema;
+  }
+
+  public static removeSchemaDatatype(columnSchema: any): any {
+    if ("datatype" in columnSchema) {
+      switch (columnSchema.datatype) {
+        case "uriTemplate":
+          delete columnSchema.datatype;
+          break;
+        case "uri":
+          columnSchema.valueUrl = "{" + columnSchema.name + "}";
+          delete columnSchema.datatype;
+          break;
+      }
+    }
+    return columnSchema;
+  }
+
+  public static makeCleanTemplate(template: any): any {
+    let copy = _.cloneDeep(template);
+    for (let i = 0; i < copy.tableSchema.columns.length; i++) {
+      copy.tableSchema.columns[i] = this.removeSchemaDatatype(
+        copy.tableSchema.columns[i]
+      );
+    }
+    return copy;
+  }
 }
 
 const DATE_FORMATS = [

--- a/src/DataDock.ImportUI/src/DataDock.ts
+++ b/src/DataDock.ImportUI/src/DataDock.ts
@@ -14,9 +14,7 @@ export class Helper {
       ) {
         return Object.assign({}, columnSchema, { datatype: "uri" });
       } else {
-        console.log("Change ", columnSchema.name, "to uriTemplate");
         var ret = Object.assign({}, columnSchema, { datatype: "uriTemplate" });
-        console.log(ret);
         return ret;
       }
     }

--- a/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
@@ -92,10 +92,17 @@ export default class DefineAdvancedRow extends Vue {
     "valueUrl" in this.value ? this.value["valueUrl"] : "";
   private errors: any = {};
   private hasErrors: boolean = false;
-  private uriTemplateValid: boolean = true;
+  private _uriTemplateValid: boolean = true;
 
   private notifyChange() {
     this.$emit("input", this.value);
+  }
+
+  @Watch("value") onValueChanged() {
+    if (this.value.datatype === "uriTemplate") {
+      console.log("Validating URI Template for ", this.value.name);
+      this.validateUriTemplate();
+    }
   }
 
   @Watch("uriTemplate") onUriTemplateChanged() {
@@ -131,6 +138,14 @@ export default class DefineAdvancedRow extends Vue {
     return !this.errors.title;
   }
 
+  private get uriTemplateValid(): boolean {
+    if (this.value.datatype === "uriTemplate") {
+      this.validateUriTemplate();
+      return this._uriTemplateValid;
+    }
+    return this._uriTemplateValid;
+  }
+
   private onUriInputError(isValid: boolean, errors: any) {
     if (isValid) {
       delete this.errors.propertyUrl;
@@ -154,19 +169,19 @@ export default class DefineAdvancedRow extends Vue {
     if (this.uriTemplate.length == 0) {
       this.errors.uriTemplate = "A non-empty URI template string is required";
     }
-    this.uriTemplateValid = !("uriTemplate" in this.errors);
+    this._uriTemplateValid = !("uriTemplate" in this.errors);
     var results = this.uriTemplate.match(this.templateRegex);
     if (!results) {
       this.errors.uriTemplate =
         "URI Template must reference one or more columns using {columnName} syntax";
-      this.uriTemplateValid = false;
+      this._uriTemplateValid = false;
     } else {
       for (let match of results) {
         let columnRef = match.substring(1, match.length - 1);
         if (!this.hasColumn(columnRef)) {
           this.errors.uriTemplate =
             "Template references a non-existant column with name " + match;
-          this.uriTemplateValid = false;
+          this._uriTemplateValid = false;
         }
       }
     }

--- a/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
@@ -91,20 +91,20 @@ export default class DefineAdvancedRow extends Vue {
   private uriTemplate: string =
     "valueUrl" in this.value ? this.value["valueUrl"] : "";
   private errors: any = {};
-  private hasErrors: boolean = false;
+  private hasErrors: boolean | undefined;
   private _uriTemplateValid: boolean = true;
 
   private notifyChange() {
     this.$emit("input", this.value);
   }
 
+/*
   @Watch("value") onValueChanged() {
     if (this.value.datatype === "uriTemplate") {
-      console.log("Validating URI Template for ", this.value.name);
       this.validateUriTemplate();
     }
   }
-
+*/
   @Watch("uriTemplate") onUriTemplateChanged() {
     this.validateUriTemplate();
     this.value.valueUrl = this.uriTemplate;
@@ -121,6 +121,7 @@ export default class DefineAdvancedRow extends Vue {
       }
     }
     if (oldState !== this.hasErrors) {
+      console.log(oldState, this.hasErrors);
       this.$emit("error", this.hasErrors, this.errors);
     }
   }

--- a/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
@@ -32,7 +32,7 @@
       ></prefixed-uri-input>
       <div class="field">
         <label :for="value.name + '_datatype'">Datatype</label>
-        <select :id="value.name + '_datatype'" v-model="datatype">
+        <select :id="value.name + '_datatype'" v-model="value.datatype">
           <option value="string">Text</option>
           <option value="uri">URI</option>
           <option value="integer">Whole Number</option>
@@ -43,7 +43,7 @@
           <option value="uriTemplate">URI Template</option>
         </select>
       </div>
-      <div class="field" v-if="datatype == 'string'">
+      <div class="field" v-if="value.datatype == 'string'">
         <label :for="value.name + '_lang'">Language</label>
         <input
           :id="value.name + '_lang'"
@@ -56,7 +56,7 @@
       <div
         class="required field"
         :class="{ error: !uriTemplateValid }"
-        v-if="datatype == 'uriTemplate'"
+        v-if="value.datatype == 'uriTemplate'"
       >
         <label :for="value.name + '_uriTemplate'">URI Template String</label>
         <input
@@ -88,25 +88,11 @@ export default class DefineAdvancedRow extends Vue {
   @Prop() private colIx!: number;
   @Prop() private resourceIdentifierBase!: string;
   @Prop() private templateMetadata: any;
-  private datatype: string = this.getDatatypeId();
   private uriTemplate: string =
     "valueUrl" in this.value ? this.value["valueUrl"] : "";
   private errors: any = {};
   private hasErrors: boolean = false;
   private uriTemplateValid: boolean = true;
-
-  private getDatatypeId(): string {
-    if ("valueUrl" in this.value) {
-      if (
-        this.value.valueUrl.startsWith("{") &&
-        this.value.valueUrl.endsWith("}")
-      ) {
-        return "uri";
-      }
-      return "uriTemplate";
-    }
-    return this.value.datatype;
-  }
 
   private notifyChange() {
     this.$emit("input", this.value);
@@ -115,30 +101,6 @@ export default class DefineAdvancedRow extends Vue {
   @Watch("uriTemplate") onUriTemplateChanged() {
     this.validateUriTemplate();
     this.value.valueUrl = this.uriTemplate;
-    this.notifyChange();
-  }
-
-  @Watch("datatype")
-  private onDatatypeChanged() {
-    switch (this.datatype) {
-      case "uri":
-        this.value.valueUrl = "{" + this.value.name + "}";
-        delete this.value.datatype;
-        break;
-      case "uriTemplate":
-        this.uriTemplate =
-          this.resourceIdentifierBase +
-          "/" +
-          this.value.name +
-          "/{" +
-          this.value.name +
-          "}";
-        delete this.value.datatype;
-        break;
-      default:
-        this.value.datatype = this.datatype;
-        delete this.value.valueUrl;
-    }
     this.notifyChange();
   }
 

--- a/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
@@ -121,7 +121,6 @@ export default class DefineAdvancedRow extends Vue {
       }
     }
     if (oldState !== this.hasErrors) {
-      console.log(oldState, this.hasErrors);
       this.$emit("error", this.hasErrors, this.errors);
     }
   }

--- a/src/DataDock.ImportUI/src/components/DefineColumns.vue
+++ b/src/DataDock.ImportUI/src/components/DefineColumns.vue
@@ -10,11 +10,12 @@
     </thead>
     <tbody>
       <define-columns-row
-        v-for="col in templateMetadata.tableSchema.columns"
-        v-bind:col="col"
+        v-for="(col, ix) in value.tableSchema.columns"
+        v-bind:value="value.tableSchema.columns[ix]"
         v-bind:resourceIdentifierBase="resourceIdentifierBase"
-        v-bind:key="col.name"
+        v-bind:key="'col_' + col.name"
         @error="onError(col.name, $event)"
+        @input="$emit('input', value)"
       ></define-columns-row>
     </tbody>
   </table>
@@ -32,7 +33,7 @@ import { ColumnInfo } from "@/DataDock";
   }
 })
 export default class DefineColumns extends Vue {
-  @Prop() private templateMetadata: any;
+  @Prop() private value: any;
   @Prop() private identifierBase!: string;
   @Prop() private resourceIdentifierBase!: string;
   private errorColumns: string[] = [];

--- a/src/DataDock.ImportUI/src/components/DefineColumnsRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineColumnsRow.vue
@@ -1,11 +1,11 @@
 <template>
   <tr>
-    <td>{{ col.name }}</td>
+    <td>{{ value.name }}</td>
     <td>
       <div class="ui field" v-bind:class="{ error: !titleValid }">
         <input
           type="text"
-          v-model="col.titles[0]"
+          v-model="value.titles[0]"
           @input="validateTitle"
           placeholder="A non-empty title is required"
         />
@@ -15,7 +15,7 @@
       </div>
     </td>
     <td>
-      <select v-model="datatype">
+      <select v-model="value.datatype">
         <option value="string">Text</option>
         <option value="uri">URI</option>
         <option value="integer">Whole Number</option>
@@ -27,7 +27,7 @@
       </select>
     </td>
     <td>
-      <input type="checkbox" v-model="col.suppressOutput" />
+      <input type="checkbox" v-model="value.suppressOutput" />
     </td>
   </tr>
 </template>
@@ -38,56 +38,19 @@ import { Component, Prop, Watch } from "vue-property-decorator";
 
 @Component
 export default class DefineColumnsRow extends Vue {
-  @Prop() private col: any;
+  @Prop() private value: any;
   @Prop() private resourceIdentifierBase!: string;
-  private datatype: string = this.getDatatypeId();
   private titleValid: boolean = true;
-
-  private getDatatypeId(): string {
-    if ("valueUrl" in this.col) {
-      if (
-        this.col.valueUrl.startsWith("{") &&
-        this.col.valueUrl.endsWith("}")
-      ) {
-        return "uri";
-      }
-      return "uriTemplate";
-    }
-    return this.col.datatype;
-  }
 
   private validateTitle() {
     const wasValid = this.titleValid;
-    if (this.col.titles[0].length > 0) {
+    if (this.value.titles[0].length > 0) {
       this.titleValid = true;
     } else {
       this.titleValid = false;
     }
     if (this.titleValid != wasValid) {
       this.$emit("error", !this.titleValid);
-    }
-  }
-
-  @Watch("datatype")
-  private onDatatypeChanged() {
-    switch (this.datatype) {
-      case "uri":
-        this.col.valueUrl = "{" + this.col.name + "}";
-        delete this.col.datatype;
-        break;
-      case "uriTemplate":
-        this.col.valueUrl =
-          this.resourceIdentifierBase +
-          "/" +
-          this.col.name +
-          "/{" +
-          this.col.name +
-          "}";
-        delete this.col.datatype;
-        break;
-      default:
-        this.col.datatype = this.datatype;
-        delete this.col.valueUrl;
     }
   }
 }

--- a/src/DataDock.ImportUI/src/components/DefineDetails.vue
+++ b/src/DataDock.ImportUI/src/components/DefineDetails.vue
@@ -99,7 +99,7 @@ export default class DefineDetails extends Vue {
 
   private validateTitle() {
     delete this.errors["title"];
-    if (this.title.length == 0) {
+    if (this.title === undefined || this.title.length == 0) {
       this.errors["title"] = "A non-empty title is required";
       this.titleValid = false;
     } else {

--- a/src/DataDock.ImportUI/src/components/DefineIdentifiers.vue
+++ b/src/DataDock.ImportUI/src/components/DefineIdentifiers.vue
@@ -39,7 +39,25 @@ export default class DefineIdentifiers extends Vue {
   @Prop() private value: any;
   @Prop() private identifierBase!: string;
   @Prop() private datasetId!: string;
-  private identifierColumn: string = "row_{_row}";
+  private _identifierColumn: string = "";
+
+  private get identifierColumn(): string {
+    if (this._identifierColumn) return this._identifierColumn;
+    if ("aboutUrl" in this.value) {
+      if (this.value.aboutUrl.endsWith("row_{_row}")){
+        return "row_{_row}";
+      }
+      if (this.value.aboutUrl.startsWith(this.identifierBase + "/resource/")) {
+        return this.value.aboutUrl.substring(this.identifierBase.length + 10);
+      }
+    }
+    return "row_{_row}";
+  }
+
+  private set identifierColumn(newValue: string) {
+    this._identifierColumn = newValue;
+    this.recalculateAboutUrl();
+  }
 
   private get aboutUrl(): string {
     return this.identifierColumn === "row_{_row}"

--- a/src/DataDock.ImportUI/src/components/DefineTemplate.vue
+++ b/src/DataDock.ImportUI/src/components/DefineTemplate.vue
@@ -6,12 +6,17 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
+import { Helper } from "@/DataDock";
 
 @Component
 export default class DefineTempalte extends Vue {
   @Prop() private value: any;
   public get templateJson(): string {
-    let json = JSON.stringify(this.value, undefined, 2);
+    let json = JSON.stringify(
+      Helper.makeCleanTemplate(this.value),
+      undefined,
+      2
+    );
     json = json
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")

--- a/src/DataDock.ImportUI/src/views/Define.vue
+++ b/src/DataDock.ImportUI/src/views/Define.vue
@@ -98,7 +98,7 @@
         </div>
         <div v-show="isActive('definitions')">
           <define-columns
-            :templateMetadata="templateMetadata"
+            v-model="templateMetadata"
             :identifierBase="identifierBase"
             :resourceIdentifierBase="resourceIdentifierBase"
             @error="onError('definitions', $event)"

--- a/src/DataDock.ImportUI/src/views/Upload.vue
+++ b/src/DataDock.ImportUI/src/views/Upload.vue
@@ -54,6 +54,7 @@
 <script lang="ts">
 import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 import Axios from "axios";
+import { Helper } from "@/DataDock";
 
 @Component
 export default class Upload extends Vue {
@@ -74,11 +75,14 @@ export default class Upload extends Vue {
       return;
     }
     let formData = new FormData();
+    let sanitizedTemplate = Helper.makeCleanTemplate(
+      this.$props.templateMetadata
+    );
     formData.append("ownerId", this.ownerId);
     formData.append("repoId", this.repoId);
     formData.append("file", this.csvFile, this.csvFileName);
     formData.append("filename", this.csvFileName);
-    formData.append("metadata", JSON.stringify(this.$props.templateMetadata));
+    formData.append("metadata", JSON.stringify(sanitizedTemplate));
     formData.append(
       "showOnHomePage",
       JSON.stringify(this.importOptions.showOnHomePage)

--- a/src/DataDock.ImportUI/tests/unit/DataDock.spec.ts
+++ b/src/DataDock.ImportUI/tests/unit/DataDock.spec.ts
@@ -1,4 +1,9 @@
-import { DatatypeSniffer, SnifferOptions, DatatypeEnum } from "@/DataDock";
+import {
+  DatatypeSniffer,
+  SnifferOptions,
+  DatatypeEnum,
+  Helper
+} from "@/DataDock";
 
 describe("DatatypeSniffer", () => {
   let datatypeSniffer = new DatatypeSniffer(new SnifferOptions());
@@ -156,6 +161,65 @@ describe("DatatypeSniffer", () => {
       expect(colInfo.hasEmptyValues).toBe(false);
       expect(colInfo.allEmptyValues).toBe(false);
       expect(colInfo.datatype).toBe(DatatypeEnum.None);
+    });
+  });
+});
+
+describe("Helper", () => {
+  describe("makeCleanTemplate", () => {
+    it("removes the datatype property from a uriTemplate column", () => {
+      var template = {
+        tableSchema: {
+          columns: [
+            {
+              name: "colA",
+              propertyUrl: "http://example.org/p",
+              datatype: "uriTemplate",
+              valueUrl: "http://example.org/id/{colA}"
+            }
+          ]
+        }
+      };
+      var sanitizedTemplate = Helper.makeCleanTemplate(template);
+      var sanitizedColA = sanitizedTemplate.tableSchema.columns[0];
+      expect(sanitizedColA).not.toHaveProperty("datatype");
+      expect(sanitizedColA).toHaveProperty("valueUrl");
+    });
+    it("replaces the datatype property for a uri column with a valueUrl property", () => {
+      var template = {
+        tableSchema: {
+          columns: [
+            {
+              name: "colA",
+              propertyUrl: "http://example.org/p",
+              datatype: "uri"
+            }
+          ]
+        }
+      };
+      var sanitizedTemplate = Helper.makeCleanTemplate(template);
+      var sanitizedColA = sanitizedTemplate.tableSchema.columns[0];
+      expect(sanitizedColA).not.toHaveProperty("datatype");
+      expect(sanitizedColA).toHaveProperty("valueUrl");
+      expect(sanitizedColA.valueUrl).toBe("{colA}");
+    });
+    it("does not modify a string column", () => {
+      var template = {
+        tableSchema: {
+          columns: [
+            {
+              name: "colA",
+              propertyUrl: "http://example.org/p",
+              datatype: "string"
+            }
+          ]
+        }
+      };
+      var sanitizedTemplate = Helper.makeCleanTemplate(template);
+      var sanitizedColA = sanitizedTemplate.tableSchema.columns[0];
+      expect(sanitizedColA).toHaveProperty("datatype");
+      expect(sanitizedColA.datatype).toBe("string");
+      expect(sanitizedColA).not.toHaveProperty("valueUrl");
     });
   });
 });

--- a/src/DataDock.ImportUI/tests/unit/DataDock.spec.ts
+++ b/src/DataDock.ImportUI/tests/unit/DataDock.spec.ts
@@ -221,5 +221,27 @@ describe("Helper", () => {
       expect(sanitizedColA.datatype).toBe("string");
       expect(sanitizedColA).not.toHaveProperty("valueUrl");
     });
+    it("Adds a uri datatype when the valueUrl is only a column reference", () => {
+      var col = {
+        name: "colA",
+        propertyUrl: "http://example.org/p",
+        valueUrl: "{colA}"
+      };
+      var annotatedTemplate = Helper.addSchemaDatatype(col);
+      expect(annotatedTemplate).toHaveProperty("datatype");
+      expect(annotatedTemplate.datatype).toBe("uri");
+      expect(annotatedTemplate.valueUrl).toBe(col.valueUrl);
+    });
+    it("Adds a uriTemplate datatype when the valueUrl is not only a column reference", () => {
+      var col = {
+        name: "colA",
+        propertyUrl: "http://example.org/p",
+        valueUrl: "http://example.org/id/{colA}"
+      };
+      var annotatedTemplate = Helper.addSchemaDatatype(col);
+      expect(annotatedTemplate).toHaveProperty("datatype");
+      expect(annotatedTemplate.datatype).toBe("uriTemplate");
+      expect(annotatedTemplate.valueUrl).toBe(col.valueUrl);
+    });
   });
 });

--- a/src/DataDock.Web/package-lock.json
+++ b/src/DataDock.Web/package-lock.json
@@ -4,11 +4,27 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@aspnet/signalr": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@aspnet/signalr/-/signalr-1.0.4.tgz",
-      "integrity": "sha512-q7HMlTZPkZCa/0UclsXvEyqNirpjRfRuwhjEeADD1i6pqe0Yx5OwuCO7+Xsc6MNKR8vE1C9MyxnSj0SecvUbTA==",
-      "dev": true
+    "@microsoft/signalr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-3.1.2.tgz",
+      "integrity": "sha512-NeOJQUvkONpbGdkm/q+riYRomInY3Jm8U1hfCWxwdGn3hoS4m54jyb2ix5V0lgOWBHwpTdgW9i3YI7TFf8AdhA==",
+      "dev": true,
+      "requires": {
+        "eventsource": "^1.0.7",
+        "request": "^2.88.0",
+        "ws": "^6.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
     },
     "accepts": {
       "version": "1.3.5",
@@ -33,6 +49,18 @@
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
+      }
+    },
+    "ajv": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "amdefine": {
@@ -234,6 +262,21 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -282,10 +325,28 @@
         "async-done": "^1.2.2"
       }
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
       "dev": true
     },
     "babel-polyfill": {
@@ -412,6 +473,15 @@
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "better-assert": {
       "version": "1.0.2",
@@ -598,6 +668,12 @@
         }
       }
     },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
     "chalk": {
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
@@ -775,6 +851,15 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
       "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "2.17.1",
@@ -961,6 +1046,15 @@
         "es5-ext": "^0.10.9"
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "date-format": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
@@ -1071,6 +1165,12 @@
         }
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1162,6 +1262,16 @@
       "requires": {
         "is-plain-object": "^2.0.1",
         "object.defaults": "^1.1.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ee-first": {
@@ -1350,6 +1460,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "dev": true
+    },
+    "eventsource": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "dev": true,
+      "requires": {
+        "original": "^1.0.0"
+      }
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -1545,6 +1664,12 @@
         "yauzl": "2.4.1"
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
     "fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
@@ -1556,6 +1681,18 @@
         "parse-node-version": "^1.0.0",
         "time-stamp": "^1.0.0"
       }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fd-slicer": {
       "version": "1.0.1",
@@ -1729,6 +1866,23 @@
         "for-in": "^1.0.1"
       }
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -1806,7 +1960,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1827,12 +1982,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1847,17 +2004,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1974,7 +2134,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1986,6 +2147,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2000,6 +2162,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2007,12 +2170,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2031,6 +2196,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2111,7 +2277,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2123,6 +2290,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2208,7 +2376,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2244,6 +2413,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2263,6 +2433,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2306,12 +2477,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -2338,6 +2511,15 @@
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.3",
@@ -2747,6 +2929,22 @@
         "glogg": "^1.0.0"
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has-ansi": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
@@ -2861,6 +3059,17 @@
         "eventemitter3": "^3.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -3142,6 +3351,12 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -3194,6 +3409,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "jasmine": {
@@ -3258,10 +3479,34 @@
       "integrity": "sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=",
       "dev": true
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
     "jsonfile": {
@@ -3271,6 +3516,18 @@
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "just-debounce": {
@@ -4049,6 +4306,12 @@
       "integrity": "sha512-V3j76KU3g/Gyl8rpdi2z72rn5zguMvTCQgAXfBe3pxEefKqXmOUOD7mvx/mNjykdxGqDVfpSoo8r+WdrkWg/1Q==",
       "dev": true
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4205,6 +4468,15 @@
         "readable-stream": "^2.0.1"
       }
     },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -4347,6 +4619,12 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
@@ -4449,6 +4727,12 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "psl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+      "dev": true
+    },
     "pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -4469,6 +4753,12 @@
         "inherits": "^2.0.3",
         "pump": "^2.0.0"
       }
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "puppeteer": {
       "version": "1.18.1",
@@ -4528,6 +4818,12 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
       "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==",
+      "dev": true
+    },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
     },
     "range-parser": {
@@ -4701,6 +4997,48 @@
         "homedir-polyfill": "^1.0.1",
         "is-absolute": "^1.0.0",
         "remove-trailing-separator": "^1.1.0"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "require-directory": {
@@ -5236,6 +5574,23 @@
         "through2": "^2.0.2"
       }
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "stack-trace": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -5547,10 +5902,35 @@
         "through2": "^2.0.3"
       }
     },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type-is": {
@@ -5684,11 +6064,30 @@
       "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
       "dev": true
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     },
     "use": {
       "version": "3.1.1",
@@ -5754,6 +6153,17 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "vinyl": {
       "version": "2.2.0",

--- a/src/DataDock.Worker.Tests/DataDock.Worker.Tests.csproj
+++ b/src/DataDock.Worker.Tests/DataDock.Worker.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="dotNetRDF" Version="2.4.0-pre0004" />
+    <PackageReference Include="dotNetRDF" Version="2.4.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.13.1" />

--- a/src/DataDock.Worker.Tests/DataDockRepositoryPublishTests.cs
+++ b/src/DataDock.Worker.Tests/DataDockRepositoryPublishTests.cs
@@ -11,24 +11,16 @@ namespace DataDock.Worker.Tests
 {
     public class DataDockRepositoryPublishTests : BaseDataDockRepositorySpec
     {
-        private Uri _datasetGraphIri;
-        private Uri _publishedSubject;
+        private readonly Uri _datasetGraphIri;
+        private readonly Uri _publishedSubject;
         public DataDockRepositoryPublishTests()
         {
             _datasetGraphIri = new Uri("http://datadock.io/test/repo/dataset");
             var initGraph = new Graph();
             _publishedSubject = new Uri("http://datadock.io/test/repo/id/subject");
             var s = initGraph.CreateUriNode(_publishedSubject);
-            QuinceStore.TripleCollections.Add(new List<Triple>
-            {
-                new Triple(s, initGraph.CreateUriNode(new Uri("http://example.org/p1")),
-                    initGraph.CreateUriNode(new Uri("http://example.org/o1")))
-            });
-            QuinceStore.ResourceStatements.Add(
-                new Tuple<INode, IList<Triple>, IList<Triple>>(
-                    s,
-                    QuinceStore.TripleCollections[0],
-                    new List<Triple>()));
+            QuinceStore.Assert(s, initGraph.CreateUriNode(new Uri("http://example.org/p1")),
+                initGraph.CreateUriNode(new Uri("http://example.org/o1")), _datasetGraphIri);
         }
 
         [Fact]

--- a/src/DataDock.Worker.Tests/HtmlFileGeneratorSpec.cs
+++ b/src/DataDock.Worker.Tests/HtmlFileGeneratorSpec.cs
@@ -49,7 +49,7 @@ namespace DataDock.Worker.Tests
             var htmlGenerator = new HtmlFileGenerator(_uriService, resourceMapperMock.Object, viewEngineMock.Object, new MockProgressLog(), 100, templateVariables);
 
             htmlGenerator.HandleResource(tripleCollection[0].Subject, tripleCollection, new List<Triple>());
-            resourceMapperMock.Verify(x=>x.GetPathFor(null), Times.Once);
+            resourceMapperMock.Verify(x=>x.GetPathFor(null), Times.Never);
             viewEngineMock.Verify(x => x.Render(It.IsAny<Uri>(), It.IsAny<IList<Triple>>(), It.IsAny<IList<Triple>>(), null), Times.Never);
         }
 

--- a/src/DataDock.Worker/DataDock.Worker.csproj
+++ b/src/DataDock.Worker/DataDock.Worker.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="..\DataDock.Common\DataDock.Common.csproj" />
     <PackageReference Include="DataDock.CsvWeb" Version="0.1.0-pre0005" />
     <PackageReference Include="DotLiquid" Version="2.0.314" />
-    <PackageReference Include="dotNetRDF" Version="2.4.0-pre0004" />
+    <PackageReference Include="dotNetRDF" Version="2.4.0" />
     <PackageReference Include="Elasticsearch.Net" Version="6.8.3" />
     <PackageReference Include="MedallionShell" Version="1.6.1" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.2" />
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
     <PackageReference Include="Octokit" Version="0.36.0" />
     <PackageReference Include="Polly" Version="7.2.0" />
-    <PackageReference Include="Quince" Version="0.5.0" />
+    <PackageReference Include="Quince" Version="0.6.0-pre0002" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="7.1.0" />
   </ItemGroup>
 

--- a/src/DataDock.Worker/DataDockRepository.cs
+++ b/src/DataDock.Worker/DataDockRepository.cs
@@ -286,6 +286,7 @@ namespace DataDock.Worker
                 var generator = _fileGeneratorFactory.MakeHtmlFileGenerator(_uriService, _htmlResourceFileMapper, templateEngine, _progressLog, HtmlFileGenerationReportInterval, templateVariables);
 
                 _quinceStore.EnumerateSubjects(generator);
+                _quinceStore.EnumerateObjects(generator);
             }
             catch (Exception ex)
             {

--- a/src/DataDock.Worker/HtmlFileGenerator.cs
+++ b/src/DataDock.Worker/HtmlFileGenerator.cs
@@ -55,7 +55,8 @@ namespace DataDock.Worker
 
         public bool HandleResource(INode resourceNode, IList<Triple> subjectStatements, IList<Triple> objectStatements)
         {
-            if (subjectStatements == null || subjectStatements.Count == 0) return true;
+            if (!(resourceNode is IUriNode)) return true;
+            if ((subjectStatements == null || subjectStatements.Count == 0) && (objectStatements == null || objectStatements.Count == 0)) return true;
             var subject = (resourceNode as IUriNode)?.Uri;
             var nquads = subject == null ? null : _uriService.GetSubjectDataUrl(subject.ToString(), "nq");
             try
@@ -104,11 +105,6 @@ namespace DataDock.Worker
                         _progressLog.Info("Generating static HTML files - {0} files created/updated.", _numFilesGenerated);
                     }
                 }
-                else
-                {
-                    _progressLog.Warn("No target path for {0}, skipping static HTML file generation.", subject);
-                }
-                
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This PR fixes the way that column datatype selection behaves across the basic and advanced views. The PR also adds a couple of missing features:
1) HTML pages are now generated for resources that are only the object of statements (i.e. they were created for URI or URI Template fields). The generator will still only generate these pages if they can be served from the Datadock repository URL
2) It is now possible to use another column as parent node for a column property