### PR TITLE
Move serilog configuration to logsettings.json

### DIFF
--- a/src/DataDock.Web/DataDock.Web.csproj
+++ b/src/DataDock.Web/DataDock.Web.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
     <PackageReference Include="Octokit" Version="0.36.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="7.1.0" />
   </ItemGroup>
 

--- a/src/DataDock.Web/Program.cs
+++ b/src/DataDock.Web/Program.cs
@@ -19,10 +19,15 @@ namespace DataDock.Web
                     var environment = webHostBuilderContext.HostingEnvironment;
                     var baseAppSettingsFile = Path.Combine(environment.ContentRootPath, "appsettings.json");
                     var environmentAppSettingsFile = Path.Combine(environment.ContentRootPath,
-                        string.Format("appsettings.{0}.json", environment.EnvironmentName.ToLower()));
+                        $"appsettings.{environment.EnvironmentName.ToLower()}.json");
+                    var logSettingsFile = Path.Combine(environment.ContentRootPath, "logsettings.json");
+                    var environmentLogSettingsFile = Path.Combine(environment.ContentRootPath,
+                        $"logsettings.{environment.EnvironmentName.ToLower()}.json");
                     configurationbuilder
                         .AddJsonFile(baseAppSettingsFile, optional: true)
                         .AddJsonFile(environmentAppSettingsFile, optional: true)
+                        .AddJsonFile(logSettingsFile, true)
+                        .AddJsonFile(environmentLogSettingsFile, true)
                         .AddEnvironmentVariables("DD_")
                         .AddEnvironmentVariables("DD_" + environment + "_");
                 })

--- a/src/DataDock.Web/Startup.cs
+++ b/src/DataDock.Web/Startup.cs
@@ -54,18 +54,7 @@ namespace DataDock.Web
             Configuration.Bind(config);
 
             // Set up logging
-            Log.Logger = new LoggerConfiguration()
-                .Enrich.FromLogContext()
-                .Enrich.WithProperty("ImageType", "Web")
-                .WriteTo.Elasticsearch(
-                    new ElasticsearchSinkOptions(new Uri(config.ElasticsearchUrl))
-                    {
-                        MinimumLogEventLevel = LogEventLevel.Debug,
-                        AutoRegisterTemplate = true,
-                        AutoRegisterTemplateVersion = AutoRegisterTemplateVersion.ESv6
-                    })
-                .CreateLogger();
-
+            Log.Logger = new LoggerConfiguration().ReadFrom.Configuration(Configuration).CreateLogger();
 
             services.AddOptions();
 

--- a/src/DataDock.Web/logsettings.json
+++ b/src/DataDock.Web/logsettings.json
@@ -1,0 +1,21 @@
+{
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Elasticsearch" ],
+    "MinimumLevel": "Debug",
+    "Enrich": [ "FromLogContext" ],
+    "WriteTo": [
+      {
+        "Name": "Elasticsearch",
+        "Args": {
+          "nodeUris": "http://elasticsearch:9200",
+          "indexFormat": "logstash-{0:yyyy.MM}",
+          "autoRegisterTemplate": true,
+          "autoRegisterTemplateVersion": "ESv6"
+        }
+      }
+    ],
+    "Properties": {
+      "ImageType": "Web"
+    }
+  }
+}

--- a/src/DataDock.Worker/DataDock.Worker.csproj
+++ b/src/DataDock.Worker/DataDock.Worker.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Octokit" Version="0.36.0" />
     <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Quince" Version="0.6.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="7.1.0" />
   </ItemGroup>
 

--- a/src/DataDock.Worker/Program.cs
+++ b/src/DataDock.Worker/Program.cs
@@ -19,15 +19,20 @@ namespace DataDock.Worker
             var builder = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json", true)
+                .AddJsonFile("logsettings.json", true)
                 .AddEnvironmentVariables("DD_");
             if (!string.IsNullOrEmpty(environment))
             {
-                builder.AddJsonFile("appsettings." + environment.ToLowerInvariant() + ".json");
+                builder.AddJsonFile($"appsettings.{environment.ToLowerInvariant()}.json", true);
+                builder.AddJsonFile($"logsettings.{environment.ToLowerInvariant()}.json", true);
             }
             var configuration = builder.Build();
             var workerConfig = new WorkerConfiguration();
             configuration.Bind(workerConfig);
+            Log.Logger = new LoggerConfiguration().ReadFrom.Configuration(configuration).CreateLogger();
             workerConfig.LogSettings();
+
+
             var serviceCollection = new ServiceCollection();
             var startup = new Startup();
             startup.ConfigureServices(serviceCollection, workerConfig);

--- a/src/DataDock.Worker/logsettings.json
+++ b/src/DataDock.Worker/logsettings.json
@@ -1,0 +1,21 @@
+{
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Elasticsearch" ],
+    "MinimumLevel": "Debug",
+    "Enrich": [ "FromLogContext" ],
+    "WriteTo": [
+      {
+        "Name": "Elasticsearch",
+        "Args": {
+          "nodeUris": "http://elasticsearch:9200",
+          "indexFormat": "logstash-{0:yyyy.MM}",
+          "autoRegisterTemplate": true,
+          "autoRegisterTemplateVersion": "ESv6"
+        }
+      }
+    ],
+    "Properties": {
+      "ImageType": "Worker"
+    }
+  }
+}


### PR DESCRIPTION
Updated startup so that Serilog configuration is read from a settings file rather than hardcoded.
Added logsettings.json files for web and worker roles with a basic configuration based on the original hard-coded configuration.
Changed the log index pattern to a monthly rotating name instead of a daily rotating name.
Fixes #205