### PR TITLE
Add support for measure columns

### DIFF
--- a/src/DataDock.ImportUI/DataDock.ImportUI.njsproj
+++ b/src/DataDock.ImportUI/DataDock.ImportUI.njsproj
@@ -1,86 +1,89 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <SchemaVersion>2.0</SchemaVersion>
-        <ProjectGuid>{e66dd2c4-7a79-4a18-95bc-0e08b37147be}</ProjectGuid>
-        <ProjectHome>.</ProjectHome>
-        <ProjectView>ShowAllFiles</ProjectView>
-        <StartupFile />
-        <WorkingDirectory>.</WorkingDirectory>
-        <OutputPath>.</OutputPath>
-        <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
-        <EnableTypeScript>true</EnableTypeScript>
-        <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">16.0</VisualStudioVersion>
-        <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
-    <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
-    <ItemGroup>
-        <Content Include="package-lock.json" />
-        <Content Include="package.json" />
-        <None Include="tsconfig.json" />
-        <Content Include="README.md" />
-        <Content Include="public\index.html" />
-        <Content Include="public\favicon.ico" />
-        <None Include="src\**\*.vue" />
-        <None Include="src\DataDock.ts" />
-        <None Include="src\main.ts" />
-        <None Include="src\shims-tsx.d.ts" />
-        <None Include="src\shims-vue.d.ts" />
-        <Content Include="src\assets\logo.png" />
-        <None Include="src\router\index.ts" />
-        <None Include="tests\unit\example.spec.ts" />
-    </ItemGroup>
-    <ItemGroup>
-        <Folder Include="DataDock.ImportUI" />
-        <Folder Include="public" />
-        <Folder Include="src" />
-        <Folder Include="src\assets" />
-        <Folder Include="src\components" />
-        <Folder Include="src\router" />
-        <Folder Include="src\views" />
-        <Folder Include="tests" />
-        <Folder Include="tests\unit" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <Import Project="$(VSToolsPath)\Node.js Tools\Microsoft.NodejsToolsV2.targets" />
-    <ProjectExtensions>
-        <VisualStudio>
-          <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
-            <WebProjectProperties>
-              <UseIIS>False</UseIIS>
-              <AutoAssignPort>True</AutoAssignPort>
-              <DevelopmentServerPort>0</DevelopmentServerPort>
-              <DevelopmentServerVPath>/</DevelopmentServerVPath>
-              <IISUrl>http://localhost:48022/</IISUrl>
-              <NTLMAuthentication>False</NTLMAuthentication>
-              <UseCustomServer>True</UseCustomServer>
-              <CustomServerUrl>http://localhost:1337</CustomServerUrl>
-              <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
-            </WebProjectProperties>
-          </FlavorProperties>
-          <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}" User="">
-            <WebProjectProperties>
-              <StartPageUrl>
-              </StartPageUrl>
-              <StartAction>CurrentPage</StartAction>
-              <AspNetDebugging>True</AspNetDebugging>
-              <SilverlightDebugging>False</SilverlightDebugging>
-              <NativeDebugging>False</NativeDebugging>
-              <SQLDebugging>False</SQLDebugging>
-              <ExternalProgram>
-              </ExternalProgram>
-              <StartExternalURL>
-              </StartExternalURL>
-              <StartCmdLineArguments>
-              </StartCmdLineArguments>
-              <StartWorkingDirectory>
-              </StartWorkingDirectory>
-              <EnableENC>False</EnableENC>
-              <AlwaysStartWebServerOnDebug>False</AlwaysStartWebServerOnDebug>
-            </WebProjectProperties>
-          </FlavorProperties>
-        </VisualStudio>
-    </ProjectExtensions>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{e66dd2c4-7a79-4a18-95bc-0e08b37147be}</ProjectGuid>
+    <ProjectHome>.</ProjectHome>
+    <ProjectView>ShowAllFiles</ProjectView>
+    <StartupFile />
+    <WorkingDirectory>.</WorkingDirectory>
+    <OutputPath>.</OutputPath>
+    <ProjectTypeGuids>{3AF33F2E-1136-4D97-BBB7-1795711AC8B8};{349c5851-65df-11da-9384-00065b846f21};{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}</ProjectTypeGuids>
+    <EnableTypeScript>true</EnableTypeScript>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">16.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'" />
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'" />
+  <ItemGroup>
+    <Content Include="package-lock.json" />
+    <Content Include="package.json" />
+    <None Include="tsconfig.json" />
+    <Content Include="README.md" />
+    <Content Include="public\index.html" />
+    <Content Include="public\favicon.ico" />
+    <None Include="src\**\*.vue" />
+    <None Include="src\DataDock.ts" />
+    <None Include="src\main.ts" />
+    <None Include="src\shims-tsx.d.ts" />
+    <None Include="src\shims-vue.d.ts" />
+    <Content Include="src\assets\logo.png" />
+    <None Include="src\router\index.ts" />
+    <None Include="tests\unit\example.spec.ts" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="DataDock.ImportUI" />
+    <Folder Include="public" />
+    <Folder Include="src" />
+    <Folder Include="src\assets" />
+    <Folder Include="src\components" />
+    <Folder Include="src\router" />
+    <Folder Include="src\views" />
+    <Folder Include="tests" />
+    <Folder Include="tests\unit" />
+  </ItemGroup>
+  <ItemGroup>
+    <TypeScriptCompile Include="tests\unit\DataDock.spec.ts" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(VSToolsPath)\Node.js Tools\Microsoft.NodejsToolsV2.targets" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
+        <WebProjectProperties>
+          <UseIIS>False</UseIIS>
+          <AutoAssignPort>True</AutoAssignPort>
+          <DevelopmentServerPort>0</DevelopmentServerPort>
+          <DevelopmentServerVPath>/</DevelopmentServerVPath>
+          <IISUrl>http://localhost:48022/</IISUrl>
+          <NTLMAuthentication>False</NTLMAuthentication>
+          <UseCustomServer>True</UseCustomServer>
+          <CustomServerUrl>http://localhost:1337</CustomServerUrl>
+          <SaveServerSettingsInUserFile>False</SaveServerSettingsInUserFile>
+        </WebProjectProperties>
+      </FlavorProperties>
+      <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}" User="">
+        <WebProjectProperties>
+          <StartPageUrl>
+          </StartPageUrl>
+          <StartAction>CurrentPage</StartAction>
+          <AspNetDebugging>True</AspNetDebugging>
+          <SilverlightDebugging>False</SilverlightDebugging>
+          <NativeDebugging>False</NativeDebugging>
+          <SQLDebugging>False</SQLDebugging>
+          <ExternalProgram>
+          </ExternalProgram>
+          <StartExternalURL>
+          </StartExternalURL>
+          <StartCmdLineArguments>
+          </StartCmdLineArguments>
+          <StartWorkingDirectory>
+          </StartWorkingDirectory>
+          <EnableENC>False</EnableENC>
+          <AlwaysStartWebServerOnDebug>False</AlwaysStartWebServerOnDebug>
+        </WebProjectProperties>
+      </FlavorProperties>
+    </VisualStudio>
+  </ProjectExtensions>
 </Project>

--- a/src/DataDock.ImportUI/package.json
+++ b/src/DataDock.ImportUI/package.json
@@ -6,6 +6,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --no-clean",
     "test:unit": "vue-cli-service test:unit",
+    "test:debug": "node --inspect-brk node_modules/.bin/vue-cli-service test:unit --no-cache --watch --runInBand",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/src/DataDock.ImportUI/src/App.vue
+++ b/src/DataDock.ImportUI/src/App.vue
@@ -180,8 +180,7 @@ export default class App extends Vue {
         propertyUrl: this.identifierBase + "/definition/" + colId
       });
     }
-    this.ensureColumnDatatype(templateMetadata);
-    return templateMetadata;
+    return Helper.makeTemplateViewModel(templateMetadata);
   }
 
   makeSchemaFromTemplate(data: string[][], file: File, template: any) {
@@ -197,16 +196,7 @@ export default class App extends Vue {
       this.$root.$data.repoId +
       "/";
     this.makeAbsolute(templateMetadata, baseUri);
-    this.ensureColumnDatatype(templateMetadata);
-    return templateMetadata;
-  }
-
-  ensureColumnDatatype(templateMetadata: any) {
-    for (let i = 0; i < templateMetadata.tableSchema.columns.length; i++) {
-      templateMetadata.tableSchema.columns[i] = Helper.addSchemaDatatype(
-        templateMetadata.tableSchema.columns[i]
-      );
-    }
+    return Helper.makeTemplateViewModel(templateMetadata);
   }
 
   readonly colRefRegExp: RegExp = /^\{[^}]+\}$/;

--- a/src/DataDock.ImportUI/src/DataDock.ts
+++ b/src/DataDock.ImportUI/src/DataDock.ts
@@ -55,6 +55,7 @@ export class Helper {
       if (c.columnType == "measure") {
         // Push down the measure column, recording its valueUrl as this columns aboutUrl
         c.aboutUrl = c.measure.valueUrl;
+        c.measure.virtual = true;
         columns.push(c.measure);
         delete c.measure;
         if (c.facets) {

--- a/src/DataDock.ImportUI/src/DataDock.ts
+++ b/src/DataDock.ImportUI/src/DataDock.ts
@@ -28,7 +28,9 @@ export class Helper {
           delete columnSchema.datatype;
           break;
         case "uri":
-          columnSchema.valueUrl = "{" + columnSchema.name + "}";
+          if (!columnSchema.virtual) {
+            columnSchema.valueUrl = "{" + columnSchema.name + "}";
+          }
           delete columnSchema.datatype;
           break;
       }

--- a/src/DataDock.ImportUI/src/DataDock.ts
+++ b/src/DataDock.ImportUI/src/DataDock.ts
@@ -58,13 +58,15 @@ export class Helper {
         c.measure.virtual = true;
         columns.push(c.measure);
         delete c.measure;
-        if (c.facets) {
-          // Push down each facet column, recording their names in the facetColumn property of this column
-          c[Schema.facetColumn] = [];
-          c.facets.forEach((facet: any) => {
-            c[Schema.facetColumn].push(facet.name);
-            columns.push(facet);
-          });
+        if ("facets" in c) {
+          if (c.facets && c.facets.length > 0) {
+            // Push down each facet column, recording their names in the facetColumn property of this column
+            c[Schema.facetColumn] = [];
+            c.facets.forEach((facet: any) => {
+              c[Schema.facetColumn].push(facet.name);
+              columns.push(facet);
+            });
+          }
           delete c.facets;
         }
       }
@@ -150,6 +152,11 @@ export class Helper {
 
       // Remove hidden property
       delete columnSchema.hidden;
+
+      // Remove any empty titles properties
+      if ("titles" in columnSchema && columnSchema.titles.length == 0) {
+        delete columnSchema.titles;
+      }
     });
     return templateMetadata;
   }

--- a/src/DataDock.ImportUI/src/DataDock.ts
+++ b/src/DataDock.ImportUI/src/DataDock.ts
@@ -6,46 +6,151 @@ export class Helper {
     return _.camelCase(_.deburr(_.trim(original)));
   }
 
-  public static addSchemaDatatype(columnSchema: any): any {
-    if ("valueUrl" in columnSchema) {
-      if (
-        columnSchema.valueUrl.startsWith("{") &&
-        columnSchema.valueUrl.endsWith("}")
-      ) {
-        return Object.assign({}, columnSchema, { datatype: "uri" });
-      } else {
-        var ret = Object.assign({}, columnSchema, { datatype: "uriTemplate" });
-        return ret;
-      }
-    }
-    return columnSchema;
+  public static getColumnWithValueUrl(
+    columnSchemas: any[],
+    valueUrl: string
+  ): any {
+    return _.findIndex(columnSchemas, (columnSchema: any) => {
+      return "valueUrl" in columnSchema && columnSchema.valueUrl === valueUrl;
+    });
   }
 
-  public static removeSchemaDatatype(columnSchema: any): any {
-    if ("datatype" in columnSchema) {
-      switch (columnSchema.datatype) {
-        case "uriTemplate":
-          delete columnSchema.datatype;
-          break;
-        case "uri":
-          if (!columnSchema.virtual) {
-            columnSchema.valueUrl = "{" + columnSchema.name + "}";
+  public static getColumnWithName(
+    columnSchemas: any[],
+    columnName: string
+  ): any {
+    return _.findIndex(columnSchemas, (columnSchema: any) => {
+      return "name" in columnSchema && columnSchema.name === columnName;
+    });
+  }
+
+  public static pullUpMeasureColumns(templateMetadata: any) {
+    let columns: any[] = templateMetadata.tableSchema.columns;
+    for (let i = 0; i < columns.length; i++) {
+      let c = columns[i];
+      if (c.virtual) break; // Measure columns must be original source CSV columns
+      if (c.columnType === "measure") {
+        let resourceColIx = this.getColumnWithValueUrl(columns, c.aboutUrl);
+        if (resourceColIx > 0) {
+          c.measure = columns[resourceColIx];
+          columns.splice(resourceColIx, 1);
+        }
+        if (Schema.facetColumn in c) {
+          c.facets = [];
+          c[Schema.facetColumn].forEach((facetName: string) => {
+            let facetColumnIx = this.getColumnWithName(columns, facetName);
+            if (facetColumnIx > 0) {
+              c.facets.push(columns[facetColumnIx]);
+              columns.splice(facetColumnIx, 1);
+            }
+          });
+        }
+      }
+    }
+  }
+
+  public static pushDownMeasureColumns(templateViewModel: any) {
+    let columns: any[] = templateViewModel.tableSchema.columns;
+    columns.forEach((c: any, i: number) => {
+      if (c.columnType == "measure") {
+        // Push down the measure column, recording its valueUrl as this columns aboutUrl
+        c.aboutUrl = c.measure.valueUrl;
+        columns.push(c.measure);
+        delete c.measure;
+        if (c.facets) {
+          // Push down each facet column, recording their names in the facetColumn property of this column
+          c[Schema.facetColumn] = [];
+          c.facets.forEach((facet: any) => {
+            c[Schema.facetColumn].push(facet.name);
+            columns.push(facet);
+          });
+          delete c.facets;
+        }
+      }
+    });
+  }
+
+  public static makeTemplateViewModel(templateMetata: any): any {
+    let templateViewModel = _.cloneDeep(templateMetata);
+    let facetColumns: string[] = [];
+    let measureResources: string[] = [];
+    templateViewModel.tableSchema.columns.forEach((columnSchema: any) => {
+      // Add uri/uriTemplate datatype when the valueUrl property is present
+      if ("valueUrl" in columnSchema) {
+        if (
+          columnSchema.valueUrl.startsWith("{") &&
+          columnSchema.valueUrl.endsWith("}")
+        ) {
+          columnSchema.datatype = "uri";
+        } else {
+          columnSchema.datatype = "uriTemplate";
+        }
+      }
+      // Add a columnType property
+      if (columnSchema.suppressOutput) {
+        columnSchema.columnType = "suppressed";
+      } else if (columnSchema[Schema.columnType]) {
+        columnSchema.columnType = columnSchema[Schema.columnType];
+        if (columnSchema.columnType == "measure") {
+          measureResources.push(columnSchema.aboutUrl);
+          if (Schema.facetColumn in columnSchema) {
+            columnSchema[Schema.facetColumn].forEach((fc: any) =>
+              facetColumns.push(fc)
+            );
           }
-          delete columnSchema.datatype;
-          break;
+        }
+      } else {
+        columnSchema.columnType = "standard";
       }
-    }
-    return columnSchema;
+
+      if (columnSchema.virtual) {
+        if (
+          "valueUrl" in columnSchema &&
+          measureResources.indexOf(columnSchema.valueUrl) >= 0
+        ) {
+          // Hide the virutal column used as the parent for a measure column
+          columnSchema.hidden = true;
+        }
+        if (facetColumns.indexOf(columnSchema.name) >= 0) {
+          // Hide the virual columns used to define facets of a measure column
+          columnSchema.hidden = true;
+        }
+      }
+    });
+    this.pullUpMeasureColumns(templateViewModel);
+    return templateViewModel;
   }
 
-  public static makeCleanTemplate(template: any): any {
-    let copy = _.cloneDeep(template);
-    for (let i = 0; i < copy.tableSchema.columns.length; i++) {
-      copy.tableSchema.columns[i] = this.removeSchemaDatatype(
-        copy.tableSchema.columns[i]
-      );
-    }
-    return copy;
+  public static makeTemplate(templateViewModel: any): any {
+    let templateMetadata = _.cloneDeep(templateViewModel);
+    this.pushDownMeasureColumns(templateMetadata);
+    templateMetadata.tableSchema.columns.forEach((columnSchema: any) => {
+      // Convert columnType to suppressOutput or dd:columnType extension property
+      if (columnSchema.columnType == "suppressed") {
+        columnSchema.suppressOutput = true;
+      } else if (columnSchema.columnType == "standard") {
+        delete columnSchema.suppressOutput;
+        delete columnSchema[Schema.columnType];
+      } else {
+        delete columnSchema.suppressOutput;
+        columnSchema[Schema.columnType] = columnSchema.columnType;
+      }
+      delete columnSchema.columnType;
+
+      if (columnSchema.datatype == "uri" && !columnSchema.virtual) {
+        // Replace uri datatype with a valueUrl property
+        columnSchema.valueUrl = "{" + columnSchema.name + "}";
+        delete columnSchema.datatype;
+      }
+      if (columnSchema.datatype == "uriTemplate") {
+        // Remove the datatype property
+        delete columnSchema.datatype;
+      }
+
+      // Remove hidden property
+      delete columnSchema.hidden;
+    });
+    return templateMetadata;
   }
 }
 
@@ -260,4 +365,11 @@ export class DatatypeSniffer {
     }
     return datatypeInfo;
   }
+}
+
+export class Schema {
+  public static SchemaBase: string = "http://schema.datadock.io/";
+  public static columnType: string = Schema.SchemaBase + "columnType";
+  public static hidden: string = Schema.SchemaBase + "hidden";
+  public static facetColumn: string = Schema.SchemaBase + "facetColumn";
 }

--- a/src/DataDock.ImportUI/src/DataDock.ts
+++ b/src/DataDock.ImportUI/src/DataDock.ts
@@ -53,8 +53,9 @@ export class Helper {
     let columns: any[] = templateViewModel.tableSchema.columns;
     columns.forEach((c: any, i: number) => {
       if (c.columnType == "measure") {
+        let measureUrl = c.measure.valueUrl;
         // Push down the measure column, recording its valueUrl as this columns aboutUrl
-        c.aboutUrl = c.measure.valueUrl;
+        c.aboutUrl = measureUrl;
         c.measure.virtual = true;
         columns.push(c.measure);
         delete c.measure;
@@ -63,12 +64,17 @@ export class Helper {
             // Push down each facet column, recording their names in the facetColumn property of this column
             c[Schema.facetColumn] = [];
             c.facets.forEach((facet: any) => {
+              facet.aboutUrl = measureUrl;
+              facet.virtual = true;
               c[Schema.facetColumn].push(facet.name);
               columns.push(facet);
             });
           }
           delete c.facets;
         }
+      } else {
+        delete c.measure;
+        delete c.facets;
       }
     });
   }

--- a/src/DataDock.ImportUI/src/components/DefineAdvanced.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvanced.vue
@@ -1,24 +1,27 @@
 <template>
-  <table class="ui celled form table" :class="{ error: hasErrors }">
-    <thead>
-      <tr>
-        <th>Column</th>
-        <th>Configuration</th>
-      </tr>
-    </thead>
-    <tbody>
-      <define-advanced-row
-        v-for="(col, ix) of value.tableSchema.columns"
-        v-model="value.tableSchema.columns[ix]"
-        v-bind:colIx="ix"
-        v-bind:resourceIdentifierBase="resourceIdentifierBase"
-        v-bind:templateMetadata="value"
-        v-bind:key="col.name"
-        @error="onError(col.name, ...arguments)"
-        @input="$emit('input', value)"
-      ></define-advanced-row>
-    </tbody>
-  </table>
+  <div>
+    <table class="ui celled form table" :class="{ error: hasErrors }">
+      <thead>
+        <tr>
+          <th>Column</th>
+          <th>Configuration</th>
+        </tr>
+      </thead>
+      <tbody>
+        <define-advanced-row
+          v-for="(col, ix) of value.tableSchema.columns"
+          v-model="value.tableSchema.columns[ix]"
+          v-bind:colIx="ix"
+          v-bind:resourceIdentifierBase="resourceIdentifierBase"
+          v-bind:templateMetadata="value"
+          v-bind:key="col.name"
+          @error="onError(col.name, ...arguments)"
+          @input="$emit('input', value)"
+        ></define-advanced-row>
+      </tbody>
+    </table>
+    <button class="ui button" @click="addVirtualColumn()">Add Column</button>
+  </div>
 </template>
 
 <script lang="ts">
@@ -53,6 +56,29 @@ export default class DefineAdvanced extends Vue {
     if (this.hasErrors != hadErrors) {
       this.$emit("error", this.hasErrors);
     }
+  }
+
+  private hasColumn(colName: string): boolean {
+    return this.value.tableSchema.columns.some((c: any) => c.name === colName);
+  }
+
+  private getNextVirtualColumnName() {
+    let prefix = "virtualCol";
+    let index = 1;
+    while (this.hasColumn(prefix + index)) {
+      index += 1;
+    }
+    return prefix + index;
+  }
+  private addVirtualColumn() {
+    let colName = this.getNextVirtualColumnName();
+    this.value.tableSchema.columns.push({
+      name: colName,
+      virtual: true,
+      datatype: "uriTemplate",
+      propertyUrl: this.identifierBase + "/definition/" + colName
+    });
+    this.$emit("input", this.value);
   }
 }
 </script>

--- a/src/DataDock.ImportUI/src/components/DefineAdvanced.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvanced.vue
@@ -12,6 +12,7 @@
           v-for="(col, ix) of value.tableSchema.columns"
           v-model="value.tableSchema.columns[ix]"
           v-bind:colIx="ix"
+          :identifierBase="identifierBase"
           v-bind:resourceIdentifierBase="resourceIdentifierBase"
           v-bind:templateMetadata="value"
           v-bind:key="col.name"

--- a/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
@@ -55,114 +55,16 @@
           <i class="question circle icon" />
         </span>
       </div>
-      <div v-if="value.columnType != 'measure'">
-        <div
-          v-if="!isVirtualColumn"
-          class="ui field required"
-          :class="{ error: !titleValid }"
-        >
-          <label :for="value.name + '_title'">Title</label>
-          <input
-            :id="value.name + 'title'"
-            type="text"
-            v-model="value.titles[0]"
-            @input="onTitleChanged"
-          />
-          <div class="ui error message" v-if="!titleValid">
-            {{ errors.title }}
-          </div>
-        </div>
-        <prefixed-uri-input
-          label="Property URI"
-          required="true"
-          v-model="value.propertyUrl"
-          v-on:error="onUriInputError"
-        ></prefixed-uri-input>
-        <div class="field">
-          <label :for="value.name + '_datatype'">Datatype</label>
-          <select
-            :id="value.name + '_datatype'"
-            v-model="value.datatype"
-            @change="onDatatypeChanged"
-          >
-            <option value="string">Text</option>
-            <option value="uri">URI</option>
-            <option value="integer">Whole Number</option>
-            <option value="decimal">Decimal Number</option>
-            <option value="date">Date</option>
-            <option value="dateTime">Date and Time</option>
-            <option value="boolean" v-if="!isVirtualColumn">True/False</option>
-            <option value="uriTemplate">URI Template</option>
-          </select>
-        </div>
-        <div
-          class="field"
-          :class="{ error: !defaultValid }"
-          v-if="
-            isVirtualColumn &&
-              value.datatype != 'uriTemplate' &&
-              value.datatype != 'uri'
-          "
-        >
-          <label :for="value.name + '_default'">Fixed Value</label>
-          <input
-            :id="value.name + '_default'"
-            type="text"
-            v-model="value.default"
-          />
-          <div class="ui error message" v-if="errors.default">
-            {{ errors.default }}
-          </div>
-        </div>
-        <div class="field" v-if="value.datatype == 'string'">
-          <label :for="value.name + '_lang'">Language</label>
-          <input
-            :id="value.name + '_lang'"
-            type="text"
-            placeholder="e.g. en, fr, de-AT"
-            v-model="value['lang']"
-            @change="notifyChange"
-          />
-        </div>
-        <uri-template-input
-          v-if="value.datatype == 'uriTemplate'"
-          v-model="this.value.valueUrl"
-          :name="value.name + '_uriTemplate'"
-          label="URI Template String"
-          :required="true"
-          :allowStatic="false"
-          :templateMetadata="templateMetadata"
-          @error="onInputError"
-        ></uri-template-input>
-        <prefixed-uri-input
-          label="Value URI"
-          required="true"
-          v-model="valueUrl"
-          v-on:error="onValueUriInputError"
-          v-if="isVirtualColumn && value.datatype == 'uri'"
-        ></prefixed-uri-input>
-        <div class="field" :class="{ error: !parentColumnValid }">
-          <label :for="value.name + '_parent'">Parent Column</label>
-          <select :id="value.name + '_parent'" v-model="parentColumn">
-            <option value="_row"> [Row] </option>
-            <option
-              v-for="col in templateMetadata.tableSchema.columns"
-              :key="'parent_' + col.name"
-              :value="col.name"
-              :disabled="col.datatype != 'uri' && col.datatype != 'uriTemplate'"
-            >
-              {{ col.name }}
-            </option>
-          </select>
-        </div>
-      </div>
+
+      <!-- Measure section (Measure columns only) -->
       <div v-if="value.columnType == 'measure'">
         <h4 class="ui dividing header">Measure</h4>
         <prefixed-uri-input
+          :key="value.name + '_measure_propertyUrl'"
           label="Property URI"
           required="true"
           v-model="value.measure.propertyUrl"
-          v-on:error="onUriInputError"
+          v-on:error="onInputError"
         ></prefixed-uri-input>
         <uri-template-input
           :name="value.name + '_measure_valueUrl'"
@@ -172,31 +74,121 @@
           v-model="value.measure.valueUrl"
           v-on:error="onInputError"
         ></uri-template-input>
-        <h4 class="ui dividing header">Value</h4>
-        <prefixed-uri-input
-          :name="value.name + '_value_propertyUrl'"
-          label="Property URI"
-          required="true"
-          v-model="value.propertyUrl"
-          v-on:error="onUriInputError"
-        ></prefixed-uri-input>
-        <div class="field">
-          <label :for="value.name + '_datatype'">Datatype</label>
-          <select
-            :id="value.name + '_datatype'"
-            v-model="value.datatype"
-            @change="onDatatypeChanged"
-          >
-            <option value="string">Text</option>
-            <option value="uri">URI</option>
-            <option value="integer">Whole Number</option>
-            <option value="decimal">Decimal Number</option>
-            <option value="date">Date</option>
-            <option value="dateTime">Date and Time</option>
-            <option value="boolean">True/False</option>
-            <option value="uriTemplate">URI Template</option>
-          </select>
+      </div>
+
+      <!-- Value section (measure and standard columns) -->
+      <h4 v-if="value.columnType == 'measure'" class="ui dividing header">
+        Value
+      </h4>
+      <div
+        v-if="!isVirtualColumn && value.columnType != 'measure'"
+        class="ui field required"
+        :class="{ error: !titleValid }"
+      >
+        <label :for="value.name + '_title'">Title</label>
+        <input
+          :id="value.name + '_title'"
+          type="text"
+          v-model="value.titles[0]"
+          @input="onTitleChanged"
+        />
+        <div class="ui error message" v-if="!titleValid">
+          {{ errors.title }}
         </div>
+      </div>
+      <prefixed-uri-input
+        :key="value.name + '_propertyUrl'"
+        :name="value.name + '_propertyUrl'"
+        label="Property URI"
+        required="true"
+        v-model="value.propertyUrl"
+        v-on:error="onInputError"
+      ></prefixed-uri-input>
+      <div class="field">
+        <label :for="value.name + '_datatype'">Datatype</label>
+        <select
+          :id="value.name + '_datatype'"
+          v-model="value.datatype"
+          @change="onDatatypeChanged"
+        >
+          <option value="string">Text</option>
+          <option value="uri">URI</option>
+          <option value="integer">Whole Number</option>
+          <option value="decimal">Decimal Number</option>
+          <option value="date">Date</option>
+          <option value="dateTime">Date and Time</option>
+          <option value="boolean" v-if="!isVirtualColumn">True/False</option>
+          <option value="uriTemplate">URI Template</option>
+        </select>
+      </div>
+      <div
+        class="field"
+        :class="{ error: !defaultValid }"
+        v-if="
+          isVirtualColumn &&
+            value.datatype != 'uriTemplate' &&
+            value.datatype != 'uri'
+        "
+      >
+        <label :for="value.name + '_default'">Fixed Value</label>
+        <input
+          :id="value.name + '_default'"
+          type="text"
+          v-model="value.default"
+        />
+        <div class="ui error message" v-if="errors.default">
+          {{ errors.default }}
+        </div>
+      </div>
+      <div class="field" v-if="value.datatype == 'string'">
+        <label :for="value.name + '_lang'">Language</label>
+        <input
+          :id="value.name + '_lang'"
+          type="text"
+          placeholder="e.g. en, fr, de-AT"
+          v-model="value['lang']"
+          @change="notifyChange"
+        />
+      </div>
+      <uri-template-input
+        v-if="value.datatype == 'uriTemplate'"
+        v-model="this.value.valueUrl"
+        :name="value.name + '_uriTemplate'"
+        label="URI Template String"
+        :required="true"
+        :allowStatic="false"
+        :templateMetadata="templateMetadata"
+        @error="onInputError"
+      ></uri-template-input>
+      <prefixed-uri-input
+        :key="value.name + '_valueUrl'"
+        label="Value URI"
+        required="true"
+        v-model="valueUrl"
+        v-on:error="onInputError"
+        v-if="isVirtualColumn && value.datatype == 'uri'"
+      ></prefixed-uri-input>
+      <div
+        v-if="value.columnType != 'measure'"
+        class="field"
+        :class="{ error: !parentColumnValid }"
+      >
+        <label :for="value.name + '_parent'">Parent Column</label>
+        <select :id="value.name + '_parent'" v-model="parentColumn">
+          <option value="_row"> [Row] </option>
+          <option
+            v-for="col in templateMetadata.tableSchema.columns"
+            :key="'parent_' + col.name"
+            :value="col.name"
+            :disabled="col.datatype != 'uri' && col.datatype != 'uriTemplate'"
+          >
+            {{ col.name }}
+          </option>
+        </select>
+      </div>
+
+      <!-- Facets section (measure column only) -->
+      <div v-if="value.columnType == 'measure'">
         <h4 class="ui dividing header">Facets</h4>
         <div v-for="facet of value.facets" :key="facet.name">
           <prefixed-uri-input
@@ -217,20 +209,19 @@
               <option value="boolean">True/False</option>
             </select>
           </div>
-          <div class="field">
-            <label :for="facet.name + '_default'">Value</label>
-            <select :id="facet.name + '_default'" v-model="facet.default">
-              <option value="string">Text</option>
-              <option value="uri">URI</option>
-              <option value="integer">Whole Number</option>
-              <option value="decimal">Decimal Number</option>
-              <option value="date">Date</option>
-              <option value="dateTime">Date and Time</option>
-              <option value="boolean">True/False</option>
-            </select>
+          <div class="field" :class="{ error: !defaultValid }">
+            <label :for="facet.name + '_default'">Facet Value</label>
+            <input
+              :id="facet.name + '_default'"
+              type="text"
+              v-model="facet.default"
+            />
+            <div class="ui error message" v-if="errors.default">
+              {{ errors.default }}
+            </div>
           </div>
         </div>
-        <button class="ui button">Add Facet</button>
+        <button class="ui button" @click="onAddFacet">Add Facet</button>
       </div>
     </td>
   </tr>
@@ -261,10 +252,8 @@ export default class DefineAdvancedRow extends Vue {
     "valueUrl" in this.value ? this.value["valueUrl"] : "";
   private valueUrl: string =
     "valueUrl" in this.value ? this.value["valueUrl"] : "";
-  //private columnType: string = this.getColumnType();
   private errors: any = {};
   private hasErrors: boolean | undefined;
-  private _uriTemplateValid: boolean = true;
   private _validator = new SnifferOptions();
 
   private notifyChange() {
@@ -322,7 +311,6 @@ export default class DefineAdvancedRow extends Vue {
 
   @Watch("uriTemplate")
   onUriTemplateChanged() {
-    this.validateUriTemplate();
     this.value.valueUrl = this.uriTemplate;
     this.notifyChange();
   }
@@ -343,21 +331,23 @@ export default class DefineAdvancedRow extends Vue {
         this.value.name +
         "}";
     }
-    this.validateUriTemplate();
     this.notifyChange();
   }
 
   private onColumnTypeChanged() {
-    if (!("measure" in this.value)) {
-      // Create a new measure virtual column
-      this.value.measure = {
-        name: this.value.name + "_measure",
-        propertyUrl: this.value.propertyUrl,
-        aboutUrl: this.value.aboutUrl,
-        valueUrl: this.value.propertyUrl + "-{_row}"
-      };
-      this.value.propertyUrl =
-        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value";
+    if (this.value.columnType == "measure") {
+      if (!("measure" in this.value)) {
+        // Create a new measure virtual column
+        this.value.measure = {
+          name: this.value.name + "_measure",
+          propertyUrl: this.value.propertyUrl,
+          aboutUrl: this.value.aboutUrl,
+          valueUrl: this.value.propertyUrl + "-{_row}"
+        };
+        this.value.propertyUrl =
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#value";
+        this.value.facets = [];
+      }
     }
   }
 
@@ -388,16 +378,6 @@ export default class DefineAdvancedRow extends Vue {
     }
     this.updateErrorFlag();
     return !this.errors.title;
-  }
-
-  private get uriTemplateValid(): boolean {
-    if (this.value.datatype === "uriTemplate") {
-      this.validateUriTemplate();
-      return this._uriTemplateValid;
-    } else {
-      delete this.errors.uriTemplate;
-      return true;
-    }
   }
 
   private get defaultValid(): boolean {
@@ -443,23 +423,6 @@ export default class DefineAdvancedRow extends Vue {
     return !this.errors.default;
   }
 
-  private onUriInputError(isValid: boolean, errors: any) {
-    if (isValid) {
-      delete this.errors.propertyUrl;
-    } else {
-      this.errors.propertyUrl = errors["value"];
-    }
-    this.updateErrorFlag();
-  }
-
-  private onValueUriInputError(isValid: boolean, errors: any) {
-    if (isValid) {
-      delete this.errors.valueUrl;
-    } else {
-      this.errors.valueUrl = errors["value"];
-    }
-  }
-
   private onInputError(
     elementName: string,
     hasError: boolean,
@@ -478,34 +441,36 @@ export default class DefineAdvancedRow extends Vue {
   private hasColumn(colName: string) {
     for (let col of this.templateMetadata.tableSchema.columns) {
       if (col.name === colName) return true;
+      if ("measure" in col && col.measure.name == colName) return true;
+      if ("facets" in col) {
+        for (let facetCol of col.facets) {
+          if (facetCol.name == colName) return true;
+        }
+      }
     }
     return false;
   }
 
-  private validateUriTemplate() {
-    delete this.errors.uriTemplate;
-    if (this.value.datatype == "uriTemplate") {
-      if (this.uriTemplate.length == 0) {
-        this.errors.uriTemplate = "A non-empty URI template string is required";
-      }
-      this._uriTemplateValid = !("uriTemplate" in this.errors);
-      var results = this.uriTemplate.match(this.templateRegex);
-      if (!results) {
-        this.errors.uriTemplate =
-          "URI Template must reference one or more columns using {columnName} syntax";
-        this._uriTemplateValid = false;
-      } else {
-        for (let match of results) {
-          let columnRef = match.substring(1, match.length - 1);
-          if (columnRef !== "_row" && !this.hasColumn(columnRef)) {
-            this.errors.uriTemplate =
-              "Template references a non-existant column with name " + match;
-            this._uriTemplateValid = false;
-          }
-        }
-      }
+  private makeVirtualColumnName() {
+    let ix = 0;
+    let columnName = "virtualColumn" + ix;
+    while (this.hasColumn(columnName)) {
+      ix += 1;
+      columnName = "virtualColumn" + ix;
     }
-    this.updateErrorFlag();
+    return columnName;
+  }
+
+  private onAddFacet() {
+    if (!("facets" in this.value)) {
+      this.value.facets = [];
+    }
+    this.value.facets.push({
+      name: this.makeVirtualColumnName(),
+      datatype: "string",
+      default: ""
+    });
+    this.$emit("input", this.value);
   }
 }
 </script>

--- a/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
@@ -10,44 +10,39 @@
           class="field"
           data-tooltip="Values in suppressed columns do not appear in the linked data."
         >
-          <div class="ui radio checkbox">
-            <input
-              type="radio"
-              id="columnTypeSuppressed"
-              value="suppressed"
-              :checked="value.columnType == 'suppressed'"
-            />
-            <label>Suppressed</label>
-          </div>
+          <input
+            type="radio"
+            id="columnTypeSuppressed"
+            value="suppressed"
+            v-model="value.columnType"
+          />
+          <label for="columnTypeSuppressed">Suppressed</label>
         </div>
         <div
           class="field"
           data-tooltip="Values in standard columns are converted to properties of the row or parent column resource."
         >
-          <div class="ui radio checkbox">
-            <input
-              type="radio"
-              id="columnTypeStandard"
-              value="standard"
-              v-model="value.columnType"
-            />
-            <label>Standard</label>
-          </div>
+          <input
+            type="radio"
+            id="columnTypeStandard"
+            value="standard"
+            v-model="value.columnType"
+            @change="onColumnTypeChanged"
+          />
+          <label for="columnTypeStandard">Standard</label>
         </div>
         <div
           class="field"
           data-tooltip="Values in measure columns are converted to a child resource with a value property and optional fixed-value properties."
         >
-          <div class="ui radio checkbox">
-            <input
-              type="radio"
-              id="columnTypeMeasure"
-              value="measure"
-              v-model="value.columnType"
-              @change="onColumnTypeChanged"
-            />
-            <label>Measure</label>
-          </div>
+          <input
+            type="radio"
+            id="columnTypeMeasure"
+            value="measure"
+            v-model="value.columnType"
+            @change="onColumnTypeChanged"
+          />
+          <label for="columnTypeMeasure">Measure</label>
         </div>
         <span
           data-tooltip="Determines how the column should be converted to linked data."
@@ -56,149 +51,154 @@
         </span>
       </div>
 
-      <!-- Measure section (Measure columns only) -->
-      <div v-if="value.columnType == 'measure'">
-        <h4 class="ui dividing header">Measure</h4>
+      <div v-if="value.columnType != 'suppressed'">
+        <!-- Measure section (Measure columns only) -->
+        <div v-if="value.columnType == 'measure'">
+          <h4 class="ui dividing header">Measure</h4>
+          <prefixed-uri-input
+            :key="value.name + '_measure_propertyUrl'"
+            label="Property URI"
+            required="true"
+            v-model="value.measure.propertyUrl"
+            v-on:error="onInputError"
+          ></prefixed-uri-input>
+          <uri-template-input
+            :name="value.name + '_measure_valueUrl'"
+            label="URI Template String"
+            required="true"
+            :templateMetadata="templateMetadata"
+            v-model="value.measure.valueUrl"
+            v-on:error="onInputError"
+          ></uri-template-input>
+        </div>
+
+        <!-- Value section (measure and standard columns) -->
+        <h4 v-if="value.columnType == 'measure'" class="ui dividing header">
+          Value
+        </h4>
+        <div
+          v-if="!isVirtualColumn && value.columnType != 'measure'"
+          class="ui field required"
+          :class="{ error: !titleValid }"
+        >
+          <label :for="value.name + '_title'">Title</label>
+          <input
+            :id="value.name + '_title'"
+            type="text"
+            v-model="value.titles[0]"
+            @input="onTitleChanged"
+          />
+          <div class="ui error message" v-if="!titleValid">
+            {{ errors.title }}
+          </div>
+        </div>
         <prefixed-uri-input
-          :key="value.name + '_measure_propertyUrl'"
+          :key="value.name + '_propertyUrl'"
+          :name="value.name + '_propertyUrl'"
           label="Property URI"
           required="true"
-          v-model="value.measure.propertyUrl"
+          v-model="value.propertyUrl"
           v-on:error="onInputError"
         ></prefixed-uri-input>
-        <uri-template-input
-          :name="value.name + '_measure_valueUrl'"
-          label="URI Template String"
-          required="true"
-          :templateMetadata="templateMetadata"
-          v-model="value.measure.valueUrl"
-          v-on:error="onInputError"
-        ></uri-template-input>
-      </div>
-
-      <!-- Value section (measure and standard columns) -->
-      <h4 v-if="value.columnType == 'measure'" class="ui dividing header">
-        Value
-      </h4>
-      <div
-        v-if="!isVirtualColumn && value.columnType != 'measure'"
-        class="ui field required"
-        :class="{ error: !titleValid }"
-      >
-        <label :for="value.name + '_title'">Title</label>
-        <input
-          :id="value.name + '_title'"
-          type="text"
-          v-model="value.titles[0]"
-          @input="onTitleChanged"
-        />
-        <div class="ui error message" v-if="!titleValid">
-          {{ errors.title }}
-        </div>
-      </div>
-      <prefixed-uri-input
-        :key="value.name + '_propertyUrl'"
-        :name="value.name + '_propertyUrl'"
-        label="Property URI"
-        required="true"
-        v-model="value.propertyUrl"
-        v-on:error="onInputError"
-      ></prefixed-uri-input>
-      <div class="field">
-        <label :for="value.name + '_datatype'">Datatype</label>
-        <select
-          :id="value.name + '_datatype'"
-          v-model="value.datatype"
-          @change="onDatatypeChanged"
-        >
-          <option value="string">Text</option>
-          <option value="uri">URI</option>
-          <option value="integer">Whole Number</option>
-          <option value="decimal">Decimal Number</option>
-          <option value="date">Date</option>
-          <option value="dateTime">Date and Time</option>
-          <option value="boolean" v-if="!isVirtualColumn">True/False</option>
-          <option value="uriTemplate">URI Template</option>
-        </select>
-      </div>
-      <div
-        class="field"
-        :class="{ error: !defaultValid }"
-        v-if="
-          isVirtualColumn &&
-            value.datatype != 'uriTemplate' &&
-            value.datatype != 'uri'
-        "
-      >
-        <label :for="value.name + '_default'">Fixed Value</label>
-        <input
-          :id="value.name + '_default'"
-          type="text"
-          v-model="value.default"
-        />
-        <div class="ui error message" v-if="errors.default">
-          {{ errors.default }}
-        </div>
-      </div>
-      <div class="field" v-if="value.datatype == 'string'">
-        <label :for="value.name + '_lang'">Language</label>
-        <input
-          :id="value.name + '_lang'"
-          type="text"
-          placeholder="e.g. en, fr, de-AT"
-          v-model="value['lang']"
-          @change="notifyChange"
-        />
-      </div>
-      <uri-template-input
-        v-if="value.datatype == 'uriTemplate'"
-        v-model="this.value.valueUrl"
-        :name="value.name + '_uriTemplate'"
-        label="URI Template String"
-        :required="true"
-        :allowStatic="false"
-        :templateMetadata="templateMetadata"
-        @error="onInputError"
-      ></uri-template-input>
-      <prefixed-uri-input
-        :key="value.name + '_valueUrl'"
-        label="Value URI"
-        required="true"
-        v-model="valueUrl"
-        v-on:error="onInputError"
-        v-if="isVirtualColumn && value.datatype == 'uri'"
-      ></prefixed-uri-input>
-      <div
-        v-if="value.columnType != 'measure'"
-        class="field"
-        :class="{ error: !parentColumnValid }"
-      >
-        <label :for="value.name + '_parent'">Parent Column</label>
-        <select :id="value.name + '_parent'" v-model="parentColumn">
-          <option value="_row"> [Row] </option>
-          <option
-            v-for="col in templateMetadata.tableSchema.columns"
-            :key="'parent_' + col.name"
-            :value="col.name"
-            :disabled="col.datatype != 'uri' && col.datatype != 'uriTemplate'"
+        <div class="field">
+          <label :for="value.name + '_datatype'">Datatype</label>
+          <select
+            :id="value.name + '_datatype'"
+            v-model="value.datatype"
+            @change="onDatatypeChanged"
           >
-            {{ col.name }}
-          </option>
-        </select>
-      </div>
-
-      <!-- Facets section (measure column only) -->
-      <div v-if="value.columnType == 'measure'">
-        <h4 class="ui dividing header">Facets</h4>
-        <div v-for="(facet, ix) of value.facets" :key="facet.name">
-          <facet
-            :key="facet.name"
-            @error="onInputError"
-            v-model="value.facets"
-            :facetIndex="ix"
-          ></facet>
+            <option value="string">Text</option>
+            <option value="uri">URI</option>
+            <option value="integer">Whole Number</option>
+            <option value="decimal">Decimal Number</option>
+            <option value="date">Date</option>
+            <option value="dateTime">Date and Time</option>
+            <option value="boolean" v-if="!isVirtualColumn">True/False</option>
+            <option value="uriTemplate">URI Template</option>
+          </select>
         </div>
-        <button class="ui button" @click="onAddFacet">Add Facet</button>
+        <div
+          class="field"
+          :class="{ error: !defaultValid }"
+          v-if="
+            isVirtualColumn &&
+              value.datatype != 'uriTemplate' &&
+              value.datatype != 'uri'
+          "
+        >
+          <label :for="value.name + '_default'">Fixed Value</label>
+          <input
+            :id="value.name + '_default'"
+            type="text"
+            v-model="value.default"
+          />
+          <div class="ui error message" v-if="errors.default">
+            {{ errors.default }}
+          </div>
+        </div>
+        <div class="field" v-if="value.datatype == 'string'">
+          <label :for="value.name + '_lang'">Language</label>
+          <input
+            :id="value.name + '_lang'"
+            type="text"
+            placeholder="e.g. en, fr, de-AT"
+            v-model="value['lang']"
+            @change="notifyChange"
+          />
+        </div>
+        <uri-template-input
+          v-if="value.datatype == 'uriTemplate'"
+          v-model="this.value.valueUrl"
+          :name="value.name + '_uriTemplate'"
+          label="URI Template String"
+          :required="true"
+          :allowStatic="false"
+          :templateMetadata="templateMetadata"
+          @error="onInputError"
+        ></uri-template-input>
+        <prefixed-uri-input
+          :key="value.name + '_valueUrl'"
+          label="Value URI"
+          required="true"
+          v-model="valueUrl"
+          v-on:error="onInputError"
+          v-if="isVirtualColumn && value.datatype == 'uri'"
+        ></prefixed-uri-input>
+        <div
+          v-if="value.columnType != 'measure'"
+          class="field"
+          :class="{ error: !parentColumnValid }"
+        >
+          <label :for="value.name + '_parent'">Parent Column</label>
+          <select :id="value.name + '_parent'" v-model="parentColumn">
+            <option value="_row"> [Row] </option>
+            <option
+              v-for="col in templateMetadata.tableSchema.columns"
+              :key="'parent_' + col.name"
+              :value="col.name"
+              :disabled="col.datatype != 'uri' && col.datatype != 'uriTemplate'"
+            >
+              {{ col.name }}
+            </option>
+          </select>
+        </div>
+
+        <!-- Facets section (measure column only) -->
+        <div v-if="value.columnType == 'measure'">
+          <h4 class="ui dividing header">Facets</h4>
+          <div v-for="(facet, ix) of value.facets" :key="facet.name">
+            <facet
+              :key="facet.name"
+              @error="onInputError"
+              v-model="value.facets"
+              :facetIndex="ix"
+            ></facet>
+            <div class="ui hidden divider"></div>
+          </div>
+          <button class="ui primary button" @click="onAddFacet">
+            Add Facet
+          </button>
+        </div>
       </div>
     </td>
   </tr>
@@ -329,6 +329,11 @@ export default class DefineAdvancedRow extends Vue {
           "http://www.w3.org/1999/02/22-rdf-syntax-ns#value";
         this.$set(this.value, "facets", []);
       }
+    } else if (this.value.columnType == "standard") {
+      if ("measure" in this.value) {
+        this.$set(this.value, "titles", [this.value.measure.titles[0]]);
+        this.$set(this.value, "propertyUrl", this.value.measure.propertyUrl);
+      }
     }
   }
 
@@ -353,7 +358,7 @@ export default class DefineAdvancedRow extends Vue {
   private get titleValid() {
     delete this.errors.title;
     if (!this.isVirtualColumn) {
-      if (this.value.titles[0].length == 0) {
+      if (this.value.titles.length == 0 || this.value.titles[0].length == 0) {
         this.errors.title = "A non-empty title is required";
       }
     }
@@ -451,7 +456,6 @@ export default class DefineAdvancedRow extends Vue {
       datatype: "string",
       default: ""
     });
-    //this.$emit("input", this.value);
   }
 }
 </script>

--- a/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
@@ -4,117 +4,233 @@
       {{ value.name }}
     </td>
     <td>
-      <div class="inline field">
-        <label :for="value.name + '_suppress'">Suppress Output</label>
-        <input
-          :id="value.name + '_suppress'"
-          type="checkbox"
-          v-model="value.suppressOutput"
-        />
-      </div>
-      <div
-        v-if="!isVirtualColumn"
-        class="ui field required"
-        :class="{ error: !titleValid }"
-      >
-        <label :for="value.name + '_title'">Title</label>
-        <input
-          :id="value.name + 'title'"
-          type="text"
-          v-model="value.titles[0]"
-          @input="onTitleChanged"
-        />
-        <div class="ui error message" v-if="!titleValid">
-          {{ errors.title }}
-        </div>
-      </div>
-      <prefixed-uri-input
-        label="Property URI"
-        required="true"
-        v-model="value.propertyUrl"
-        v-on:error="onUriInputError"
-      ></prefixed-uri-input>
-      <div class="field">
-        <label :for="value.name + '_datatype'">Datatype</label>
-        <select
-          :id="value.name + '_datatype'"
-          v-model="value.datatype"
-          @change="onDatatypeChanged"
+      <div class="inline fields">
+        <label :for="value.name + '_columnType'">Column Type: </label>
+        <div
+          class="field"
+          data-tooltip="Values in suppressed columns do not appear in the linked data."
         >
-          <option value="string">Text</option>
-          <option value="uri">URI</option>
-          <option value="integer">Whole Number</option>
-          <option value="decimal">Decimal Number</option>
-          <option value="date">Date</option>
-          <option value="dateTime">Date and Time</option>
-          <option value="boolean" v-if="!isVirtualColumn">True/False</option>
-          <option value="uriTemplate">URI Template</option>
-        </select>
-      </div>
-      <div
-        class="field"
-        :class="{ error: !defaultValid }"
-        v-if="
-          isVirtualColumn &&
-            value.datatype != 'uriTemplate' &&
-            value.datatype != 'uri'
-        "
-      >
-        <label :for="value.name + '_default'">Fixed Value</label>
-        <input
-          :id="value.name + '_default'"
-          type="text"
-          v-model="value.default"
-        />
-        <div class="ui error message" v-if="errors.default">
-          {{ errors.default }}
+          <div class="ui radio checkbox">
+            <input
+              type="radio"
+              id="columnTypeSuppressed"
+              value="suppressed"
+              :checked="value.columnType == 'suppressed'"
+            />
+            <label>Suppressed</label>
+          </div>
         </div>
-      </div>
-      <div class="field" v-if="value.datatype == 'string'">
-        <label :for="value.name + '_lang'">Language</label>
-        <input
-          :id="value.name + '_lang'"
-          type="text"
-          placeholder="e.g. en, fr, de-AT"
-          v-model="value['lang']"
-          @change="notifyChange"
-        />
-      </div>
-      <div
-        class="required field"
-        :class="{ error: !uriTemplateValid }"
-        v-if="value.datatype == 'uriTemplate'"
-      >
-        <label :for="value.name + '_uriTemplate'">URI Template String</label>
-        <input
-          :id="value.name + '_uriTemplate'"
-          type="text"
-          v-model="uriTemplate"
-        />
-        <div class="ui error message" v-if="!uriTemplateValid">
-          {{ errors.uriTemplate }}
+        <div
+          class="field"
+          data-tooltip="Values in standard columns are converted to properties of the row or parent column resource."
+        >
+          <div class="ui radio checkbox">
+            <input
+              type="radio"
+              id="columnTypeStandard"
+              value="standard"
+              v-model="value.columnType"
+            />
+            <label>Standard</label>
+          </div>
         </div>
+        <div
+          class="field"
+          data-tooltip="Values in measure columns are converted to a child resource with a value property and optional fixed-value properties."
+        >
+          <div class="ui radio checkbox">
+            <input
+              type="radio"
+              id="columnTypeMeasure"
+              value="measure"
+              v-model="value.columnType"
+              @change="onColumnTypeChanged"
+            />
+            <label>Measure</label>
+          </div>
+        </div>
+        <span
+          data-tooltip="Determines how the column should be converted to linked data."
+        >
+          <i class="question circle icon" />
+        </span>
       </div>
-      <prefixed-uri-input
-        label="Value URI"
-        required="true"
-        v-model="valueUrl"
-        v-on:error="onValueUriInputError"
-        v-if="isVirtualColumn && value.datatype == 'uri'"
-      ></prefixed-uri-input>
-      <div class="field" :class="{ error: !parentColumnValid }">
-        <label :for="value.name + '_parent'">Parent Column</label>
-        <select :id="value.name + '_parent'" v-model="parentColumn">
-          <option value="_row"> [Row] </option>
-          <option
-            v-for="col in templateMetadata.tableSchema.columns"
-            :key="'parent_' + col.name"
-            :value="col.name"
-            :disabled="col.datatype != 'uri' && col.datatype != 'uriTemplate'"
+      <div v-if="value.columnType != 'measure'">
+        <div
+          v-if="!isVirtualColumn"
+          class="ui field required"
+          :class="{ error: !titleValid }"
+        >
+          <label :for="value.name + '_title'">Title</label>
+          <input
+            :id="value.name + 'title'"
+            type="text"
+            v-model="value.titles[0]"
+            @input="onTitleChanged"
+          />
+          <div class="ui error message" v-if="!titleValid">
+            {{ errors.title }}
+          </div>
+        </div>
+        <prefixed-uri-input
+          label="Property URI"
+          required="true"
+          v-model="value.propertyUrl"
+          v-on:error="onUriInputError"
+        ></prefixed-uri-input>
+        <div class="field">
+          <label :for="value.name + '_datatype'">Datatype</label>
+          <select
+            :id="value.name + '_datatype'"
+            v-model="value.datatype"
+            @change="onDatatypeChanged"
           >
-            {{ col.name }}
-          </option>
-        </select>
+            <option value="string">Text</option>
+            <option value="uri">URI</option>
+            <option value="integer">Whole Number</option>
+            <option value="decimal">Decimal Number</option>
+            <option value="date">Date</option>
+            <option value="dateTime">Date and Time</option>
+            <option value="boolean" v-if="!isVirtualColumn">True/False</option>
+            <option value="uriTemplate">URI Template</option>
+          </select>
+        </div>
+        <div
+          class="field"
+          :class="{ error: !defaultValid }"
+          v-if="
+            isVirtualColumn &&
+              value.datatype != 'uriTemplate' &&
+              value.datatype != 'uri'
+          "
+        >
+          <label :for="value.name + '_default'">Fixed Value</label>
+          <input
+            :id="value.name + '_default'"
+            type="text"
+            v-model="value.default"
+          />
+          <div class="ui error message" v-if="errors.default">
+            {{ errors.default }}
+          </div>
+        </div>
+        <div class="field" v-if="value.datatype == 'string'">
+          <label :for="value.name + '_lang'">Language</label>
+          <input
+            :id="value.name + '_lang'"
+            type="text"
+            placeholder="e.g. en, fr, de-AT"
+            v-model="value['lang']"
+            @change="notifyChange"
+          />
+        </div>
+        <uri-template-input
+          v-if="value.datatype == 'uriTemplate'"
+          v-model="this.value.valueUrl"
+          :name="value.name + '_uriTemplate'"
+          label="URI Template String"
+          :required="true"
+          :allowStatic="false"
+          :templateMetadata="templateMetadata"
+          @error="onInputError"
+        ></uri-template-input>
+        <prefixed-uri-input
+          label="Value URI"
+          required="true"
+          v-model="valueUrl"
+          v-on:error="onValueUriInputError"
+          v-if="isVirtualColumn && value.datatype == 'uri'"
+        ></prefixed-uri-input>
+        <div class="field" :class="{ error: !parentColumnValid }">
+          <label :for="value.name + '_parent'">Parent Column</label>
+          <select :id="value.name + '_parent'" v-model="parentColumn">
+            <option value="_row"> [Row] </option>
+            <option
+              v-for="col in templateMetadata.tableSchema.columns"
+              :key="'parent_' + col.name"
+              :value="col.name"
+              :disabled="col.datatype != 'uri' && col.datatype != 'uriTemplate'"
+            >
+              {{ col.name }}
+            </option>
+          </select>
+        </div>
+      </div>
+      <div v-if="value.columnType == 'measure'">
+        <h4 class="ui dividing header">Measure</h4>
+        <prefixed-uri-input
+          label="Property URI"
+          required="true"
+          v-model="value.measure.propertyUrl"
+          v-on:error="onUriInputError"
+        ></prefixed-uri-input>
+        <uri-template-input
+          :name="value.name + '_measure_valueUrl'"
+          label="URI Template String"
+          required="true"
+          :templateMetadata="templateMetadata"
+          v-model="value.measure.valueUrl"
+          v-on:error="onInputError"
+        ></uri-template-input>
+        <h4 class="ui dividing header">Value</h4>
+        <prefixed-uri-input
+          :name="value.name + '_value_propertyUrl'"
+          label="Property URI"
+          required="true"
+          v-model="value.propertyUrl"
+          v-on:error="onUriInputError"
+        ></prefixed-uri-input>
+        <div class="field">
+          <label :for="value.name + '_datatype'">Datatype</label>
+          <select
+            :id="value.name + '_datatype'"
+            v-model="value.datatype"
+            @change="onDatatypeChanged"
+          >
+            <option value="string">Text</option>
+            <option value="uri">URI</option>
+            <option value="integer">Whole Number</option>
+            <option value="decimal">Decimal Number</option>
+            <option value="date">Date</option>
+            <option value="dateTime">Date and Time</option>
+            <option value="boolean">True/False</option>
+            <option value="uriTemplate">URI Template</option>
+          </select>
+        </div>
+        <h4 class="ui dividing header">Facets</h4>
+        <div v-for="facet of value.facets" :key="facet.name">
+          <prefixed-uri-input
+            :name="facet.name + '_propertyUrl'"
+            label="Facet Property URI"
+            required="true"
+            v-model="facet.propertyUrl"
+            v-on:error="onInputError"
+          ></prefixed-uri-input>
+          <div class="field">
+            <label :for="facet.name + '_datatype'">Datatype</label>
+            <select :id="facet.name + '_datatype'" v-model="facet.datatype">
+              <option value="string">Text</option>
+              <option value="integer">Whole Number</option>
+              <option value="decimal">Decimal Number</option>
+              <option value="date">Date</option>
+              <option value="dateTime">Date and Time</option>
+              <option value="boolean">True/False</option>
+            </select>
+          </div>
+          <div class="field">
+            <label :for="facet.name + '_default'">Value</label>
+            <select :id="facet.name + '_default'" v-model="facet.default">
+              <option value="string">Text</option>
+              <option value="uri">URI</option>
+              <option value="integer">Whole Number</option>
+              <option value="decimal">Decimal Number</option>
+              <option value="date">Date</option>
+              <option value="dateTime">Date and Time</option>
+              <option value="boolean">True/False</option>
+            </select>
+          </div>
+        </div>
+        <button class="ui button">Add Facet</button>
       </div>
     </td>
   </tr>
@@ -125,23 +241,27 @@ import Vue from "vue";
 import { Component, Prop, Watch } from "vue-property-decorator";
 import DefineColumnsRow from "@/components/DefineColumnsRow.vue";
 import PrefixedUriInput from "@/components/PrefixedUriInput.vue";
+import UriTemplateInput from "@/components/UriTemplateInput.vue";
 import * as _ from "lodash";
-import { Helper, SnifferOptions } from "@/DataDock";
+import { Helper, SnifferOptions, Schema } from "@/DataDock";
 
 @Component({
   components: {
-    PrefixedUriInput
+    PrefixedUriInput,
+    UriTemplateInput
   }
 })
 export default class DefineAdvancedRow extends Vue {
   @Prop() private value: any;
   @Prop() private colIx!: number;
+  @Prop() private identifierBase!: string;
   @Prop() private resourceIdentifierBase!: string;
   @Prop() private templateMetadata: any;
   private uriTemplate: string =
     "valueUrl" in this.value ? this.value["valueUrl"] : "";
   private valueUrl: string =
     "valueUrl" in this.value ? this.value["valueUrl"] : "";
+  //private columnType: string = this.getColumnType();
   private errors: any = {};
   private hasErrors: boolean | undefined;
   private _uriTemplateValid: boolean = true;
@@ -214,8 +334,31 @@ export default class DefineAdvancedRow extends Vue {
   }
 
   private onDatatypeChanged() {
+    if (this.value.datatype == "uriTemplate" && !("valueUrl" in this.value)) {
+      this.value.valueUrl =
+        this.identifierBase +
+        "/" +
+        this.value.name +
+        "/{" +
+        this.value.name +
+        "}";
+    }
     this.validateUriTemplate();
     this.notifyChange();
+  }
+
+  private onColumnTypeChanged() {
+    if (!("measure" in this.value)) {
+      // Create a new measure virtual column
+      this.value.measure = {
+        name: this.value.name + "_measure",
+        propertyUrl: this.value.propertyUrl,
+        aboutUrl: this.value.aboutUrl,
+        valueUrl: this.value.propertyUrl + "-{_row}"
+      };
+      this.value.propertyUrl =
+        "http://www.w3.org/1999/02/22-rdf-syntax-ns#value";
+    }
   }
 
   private updateErrorFlag() {
@@ -315,6 +458,19 @@ export default class DefineAdvancedRow extends Vue {
     } else {
       this.errors.valueUrl = errors["value"];
     }
+  }
+
+  private onInputError(
+    elementName: string,
+    hasError: boolean,
+    errorMessage: string
+  ) {
+    if (hasError) {
+      this.errors[elementName] = errorMessage;
+    } else {
+      delete this.errors[elementName];
+    }
+    this.updateErrorFlag();
   }
 
   private readonly templateRegex: RegExp = /{([^}]+)}/g;

--- a/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineAdvancedRow.vue
@@ -190,36 +190,13 @@
       <!-- Facets section (measure column only) -->
       <div v-if="value.columnType == 'measure'">
         <h4 class="ui dividing header">Facets</h4>
-        <div v-for="facet of value.facets" :key="facet.name">
-          <prefixed-uri-input
-            :name="facet.name + '_propertyUrl'"
-            label="Facet Property URI"
-            required="true"
-            v-model="facet.propertyUrl"
-            v-on:error="onInputError"
-          ></prefixed-uri-input>
-          <div class="field">
-            <label :for="facet.name + '_datatype'">Datatype</label>
-            <select :id="facet.name + '_datatype'" v-model="facet.datatype">
-              <option value="string">Text</option>
-              <option value="integer">Whole Number</option>
-              <option value="decimal">Decimal Number</option>
-              <option value="date">Date</option>
-              <option value="dateTime">Date and Time</option>
-              <option value="boolean">True/False</option>
-            </select>
-          </div>
-          <div class="field" :class="{ error: !defaultValid }">
-            <label :for="facet.name + '_default'">Facet Value</label>
-            <input
-              :id="facet.name + '_default'"
-              type="text"
-              v-model="facet.default"
-            />
-            <div class="ui error message" v-if="errors.default">
-              {{ errors.default }}
-            </div>
-          </div>
+        <div v-for="(facet, ix) of value.facets" :key="facet.name">
+          <facet
+            :key="facet.name"
+            @error="onInputError"
+            v-model="value.facets"
+            :facetIndex="ix"
+          ></facet>
         </div>
         <button class="ui button" @click="onAddFacet">Add Facet</button>
       </div>
@@ -233,13 +210,15 @@ import { Component, Prop, Watch } from "vue-property-decorator";
 import DefineColumnsRow from "@/components/DefineColumnsRow.vue";
 import PrefixedUriInput from "@/components/PrefixedUriInput.vue";
 import UriTemplateInput from "@/components/UriTemplateInput.vue";
+import Facet from "@/components/Facet.vue";
 import * as _ from "lodash";
 import { Helper, SnifferOptions, Schema } from "@/DataDock";
 
 @Component({
   components: {
     PrefixedUriInput,
-    UriTemplateInput
+    UriTemplateInput,
+    Facet
   }
 })
 export default class DefineAdvancedRow extends Vue {
@@ -338,15 +317,17 @@ export default class DefineAdvancedRow extends Vue {
     if (this.value.columnType == "measure") {
       if (!("measure" in this.value)) {
         // Create a new measure virtual column
-        this.value.measure = {
+        this.$set(this.value, "measure", {
           name: this.value.name + "_measure",
+          titles: [this.value.titles[0]],
           propertyUrl: this.value.propertyUrl,
           aboutUrl: this.value.aboutUrl,
           valueUrl: this.value.propertyUrl + "-{_row}"
-        };
+        });
+        this.value.titles.splice(0);
         this.value.propertyUrl =
           "http://www.w3.org/1999/02/22-rdf-syntax-ns#value";
-        this.value.facets = [];
+        this.$set(this.value, "facets", []);
       }
     }
   }
@@ -463,14 +444,14 @@ export default class DefineAdvancedRow extends Vue {
 
   private onAddFacet() {
     if (!("facets" in this.value)) {
-      this.value.facets = [];
     }
     this.value.facets.push({
       name: this.makeVirtualColumnName(),
+      propertyUrl: "",
       datatype: "string",
       default: ""
     });
-    this.$emit("input", this.value);
+    //this.$emit("input", this.value);
   }
 }
 </script>

--- a/src/DataDock.ImportUI/src/components/DefineColumnsRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineColumnsRow.vue
@@ -32,7 +32,7 @@
       </select>
     </td>
     <td v-if="!value.virtual">
-      <input type="checkbox" v-model="value.suppressOutput" />
+      <input type="checkbox" v-model="suppressed" />
     </td>
   </tr>
 </template>
@@ -46,6 +46,14 @@ export default class DefineColumnsRow extends Vue {
   @Prop() private value: any;
   @Prop() private resourceIdentifierBase!: string;
   private titleValid: boolean = true;
+
+  private get suppressed(): boolean {
+    return this.value.columnType == "suppressed";
+  }
+
+  private set suppressed(newValue: boolean) {
+    this.value.columnType = newValue ? "suppressed" : "standard";
+  }
 
   private validateTitle() {
     const wasValid = this.titleValid;

--- a/src/DataDock.ImportUI/src/components/DefineColumnsRow.vue
+++ b/src/DataDock.ImportUI/src/components/DefineColumnsRow.vue
@@ -1,7 +1,12 @@
 <template>
   <tr>
     <td>{{ value.name }}</td>
-    <td>
+    <td colspan="3" v-if="value.virtual">
+      <div class="ui info message">
+        Virtual Column
+      </div>
+    </td>
+    <td v-if="!value.virtual">
       <div class="ui field" v-bind:class="{ error: !titleValid }">
         <input
           type="text"
@@ -14,7 +19,7 @@
         </div>
       </div>
     </td>
-    <td>
+    <td v-if="!value.virtual">
       <select v-model="value.datatype">
         <option value="string">Text</option>
         <option value="uri">URI</option>
@@ -26,7 +31,7 @@
         <option value="uriTemplate">URI Template</option>
       </select>
     </td>
-    <td>
+    <td v-if="!value.virtual">
       <input type="checkbox" v-model="value.suppressOutput" />
     </td>
   </tr>

--- a/src/DataDock.ImportUI/src/components/DefineIdentifiers.vue
+++ b/src/DataDock.ImportUI/src/components/DefineIdentifiers.vue
@@ -21,7 +21,7 @@
             v-bind:key="col.name"
             v-bind:value="col.name + '/{' + col.name + '}'"
           >
-            {{ col.titles[0] }}
+            {{ "titles" in col ? col.titles[0] : col.name }}
           </option>
         </select>
       </div>

--- a/src/DataDock.ImportUI/src/components/DefinePreview.vue
+++ b/src/DataDock.ImportUI/src/components/DefinePreview.vue
@@ -8,10 +8,10 @@
       <thead>
         <tr>
           <th
-            v-for="(col, colIx) in templateMetadata.tableSchema.columns"
+            v-for="colIx in nonVirtualColumnIndexes"
             v-bind:key="'col_' + colIx"
           >
-            {{ col.titles[0] }}
+            {{ templateMetadata.tableSchema.columns[colIx].titles[0] }}
           </th>
         </tr>
       </thead>
@@ -45,6 +45,16 @@ export default class DefinePreview extends Vue {
 
   get page() {
     return this.data.slice(1, this.pageSize);
+  }
+
+  get nonVirtualColumnIndexes(): number[] {
+    let indexes = [];
+    for (let i = 0; i < this.templateMetadata.tableSchema.columns.length; i++) {
+      if (!this.templateMetadata.tableSchema.columns[i].virtual) {
+        indexes.push(i);
+      }
+    }
+    return indexes;
   }
 }
 </script>

--- a/src/DataDock.ImportUI/src/components/DefineTemplate.vue
+++ b/src/DataDock.ImportUI/src/components/DefineTemplate.vue
@@ -12,11 +12,7 @@ import { Helper } from "@/DataDock";
 export default class DefineTemplate extends Vue {
   @Prop() private value: any;
   public get templateJson(): string {
-    let json = JSON.stringify(
-      Helper.makeCleanTemplate(this.value),
-      undefined,
-      2
-    );
+    let json = JSON.stringify(Helper.makeTemplate(this.value), undefined, 2);
     json = json
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")

--- a/src/DataDock.ImportUI/src/components/DefineTemplate.vue
+++ b/src/DataDock.ImportUI/src/components/DefineTemplate.vue
@@ -9,7 +9,7 @@ import { Component, Prop } from "vue-property-decorator";
 import { Helper } from "@/DataDock";
 
 @Component
-export default class DefineTempalte extends Vue {
+export default class DefineTemplate extends Vue {
   @Prop() private value: any;
   public get templateJson(): string {
     let json = JSON.stringify(

--- a/src/DataDock.ImportUI/src/components/Facet.vue
+++ b/src/DataDock.ImportUI/src/components/Facet.vue
@@ -103,6 +103,8 @@ export default class Facet extends Vue {
 
   private onDeleteFacet() {
     this.value.splice(this.facetIndex, 1);
+    // Clear any errors associated with this facet
+    this.$emit("error", this.$vnode.key, false, "");
   }
 
   private onInputError(

--- a/src/DataDock.ImportUI/src/components/Facet.vue
+++ b/src/DataDock.ImportUI/src/components/Facet.vue
@@ -1,6 +1,15 @@
 <template>
-  <div>
+  <div class="ui segment">
+    <button
+      class="ui small compact icon basic red button"
+      style="float: right"
+      data-tooltip="Delete this facet"
+      @click="onDeleteFacet"
+    >
+      <i class="icon trash"></i>
+    </button>
     <prefixed-uri-input
+      class="clear-right"
       :key="$vnode.key + '_propertyUrl'"
       label="Facet Property URI"
       :required="true"
@@ -90,6 +99,10 @@ export default class Facet extends Vue {
     }
     this.updateErrorFlag();
     return !this.errors.default;
+  }
+
+  private onDeleteFacet() {
+    this.value.splice(this.facetIndex, 1);
   }
 
   private onInputError(

--- a/src/DataDock.ImportUI/src/components/Facet.vue
+++ b/src/DataDock.ImportUI/src/components/Facet.vue
@@ -1,0 +1,127 @@
+<template>
+  <div>
+    <prefixed-uri-input
+      :key="$vnode.key + '_propertyUrl'"
+      label="Facet Property URI"
+      :required="true"
+      v-model="facet.propertyUrl"
+      v-on:error="onInputError"
+    ></prefixed-uri-input>
+    <div class="field">
+      <label :for="$vnode.key + '_datatype'">Datatype</label>
+      <select :id="$vnode.key + '_datatype'" v-model="facet.datatype">
+        <option value="string">Text</option>
+        <option value="integer">Whole Number</option>
+        <option value="decimal">Decimal Number</option>
+        <option value="date">Date</option>
+        <option value="dateTime">Date and Time</option>
+        <option value="boolean">True/False</option>
+      </select>
+    </div>
+    <div class="field" :class="{ error: !defaultValid }">
+      <label :for="$vnode.key + '_default'">Facet Value</label>
+      <input
+        :id="$vnode.key + '_default'"
+        type="text"
+        v-model="facet.default"
+      />
+      <div class="ui error message" v-if="errors.default">
+        {{ errors.default }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component, Prop, Watch } from "vue-property-decorator";
+import PrefixedUriInput from "@/components/PrefixedUriInput.vue";
+import { SnifferOptions } from "@/DataDock";
+
+@Component({ components: { PrefixedUriInput } })
+export default class Facet extends Vue {
+  @Prop() private value: any;
+  @Prop() private facetIndex!: number;
+  private hasErrors: boolean = false;
+  private errors: any = {};
+
+  private get facet(): any {
+    return this.value[this.facetIndex];
+  }
+
+  private get defaultValid(): boolean {
+    let validator = new SnifferOptions();
+    delete this.errors.default;
+    switch (this.value.datatype) {
+      case "integer":
+        if (!validator.isInteger(this.value.default)) {
+          this.errors.default = "Invalid integer value";
+        }
+        break;
+      case "decimal":
+        if (!validator.isDecimal(this.value.default)) {
+          this.errors.default = "Invalid decimal value";
+        }
+        break;
+      case "float":
+        if (!validator.isFloat(this.value.default)) {
+          this.errors.default = "Invalid floating point value";
+        }
+        break;
+      case "date":
+        if (!validator.isDate(this.value.default)) {
+          this.errors.default = "Invalid date value";
+        }
+        break;
+      case "dateTime":
+        if (!validator.isDateTime(this.value.default)) {
+          this.errors.default = "Invalid date/time value";
+        }
+        break;
+      case "boolean":
+        if (!validator.isBoolean(this.value.default)) {
+          this.errors.default = "Invalid boolean value";
+        }
+        break;
+      case "uri":
+        if (!validator.isUri(this.value.default)) {
+          this.errors.default = "Invalid URL";
+        }
+    }
+    this.updateErrorFlag();
+    return !this.errors.default;
+  }
+
+  private onInputError(
+    elementName: string,
+    hasError: boolean,
+    errorMessage: string
+  ) {
+    if (hasError) {
+      this.errors[elementName] = errorMessage;
+    } else {
+      delete this.errors[elementName];
+    }
+    this.updateErrorFlag();
+  }
+
+  private updateErrorFlag() {
+    let oldState = this.hasErrors;
+    this.hasErrors = false;
+    for (let k in this.errors) {
+      if (this.errors[k]) {
+        this.hasErrors = true;
+        break;
+      }
+    }
+    if (oldState !== this.hasErrors) {
+      this.$emit(
+        "error",
+        this.$vnode.key,
+        this.hasErrors,
+        this.hasErrors ? "Error in facet definition" : ""
+      );
+    }
+  }
+}
+</script>

--- a/src/DataDock.ImportUI/src/components/PrefixedUriInput.vue
+++ b/src/DataDock.ImportUI/src/components/PrefixedUriInput.vue
@@ -33,13 +33,18 @@ export default class PrefixedUriInput extends Vue {
   private usePrefixcc: boolean = true;
   private onDebouncedUriInput!: () => void;
   private curieOrUri: string = this.value;
-  private expandedUri: string = this.value;
+  private expandedUri: string = this.value ?? "";
   private hasError: boolean = false;
   private uriEdited: boolean = false;
   private errorMessage: string = "";
 
   created() {
     this.onDebouncedUriInput = _.debounce(this.expandCurie, 500);
+  }
+
+  mounted() {
+    this.expandCurie();
+    this.validate();
   }
 
   getPrefixedPart(curie: string) {
@@ -93,7 +98,11 @@ export default class PrefixedUriInput extends Vue {
   }
 
   notifyValue() {
+    this.validate();
     this.$emit("input", this.expandedUri);
+  }
+
+  validate() {
     if (this.expandedUri == "" && this.required){
       this.setError("A value is required");
     } else if (!this.expandedUri.includes(":")) {
@@ -127,9 +136,11 @@ export default class PrefixedUriInput extends Vue {
         this.expandedUri = this.namespace + this.suffix;
       }
     } else {
+      this.prefix = "";
       this.namespace = "";
       this.expandedUri = this.curieOrUri ?? "";
     }
+    this.validate();
   }
 }
 </script>

--- a/src/DataDock.ImportUI/src/components/PrefixedUriInput.vue
+++ b/src/DataDock.ImportUI/src/components/PrefixedUriInput.vue
@@ -23,7 +23,7 @@ export default class PrefixedUriInput extends Vue {
   private namespace: string = "";
   private prefix!: string;
   private suffix!: string;
-  private curieOrUri: string = this.value;
+  private curieOrUri: string = this.value ?? "";
   private usePrefixcc: boolean = true;
   private onDebouncedUriInput!: () => void;
   private uriValid: boolean = true;

--- a/src/DataDock.ImportUI/src/components/UriTemplateInput.vue
+++ b/src/DataDock.ImportUI/src/components/UriTemplateInput.vue
@@ -1,0 +1,91 @@
+<template>
+  <div class="field" :class="{ error: hasErrors, required: required }">
+    <label :for="name">{{ label }}</label>
+    <input :id="name" type="text" v-model="uriTemplate" />
+    <div class="ui error message" v-if="hasErrors">
+      {{ errorMessage }}
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component, Prop, Watch } from "vue-property-decorator";
+
+@Component
+export default class UriTemplateInput extends Vue {
+  @Prop() private name!: string;
+  @Prop() private label!: string;
+  @Prop() private value!: string;
+  @Prop() private required!: boolean;
+  @Prop() private allowStatic!: boolean;
+  @Prop() private templateMetadata!: any;
+  private uriTemplate: string = this.value ?? "";
+  private hasErrors: boolean = false;
+  private errorMessage: string = "";
+  private readonly templateRegex: RegExp = /{([^}]+)}/g;
+
+  created() {
+    this.validateUriTemplate();
+  }
+
+  private get uriTemplateValid(): boolean {
+    this.validateUriTemplate();
+    return this.hasErrors;
+  }
+
+  private setError(errorMessage: string) {
+    this.errorMessage = errorMessage;
+    this.hasErrors = true;
+  }
+
+  private hasColumn(columnRef: string): boolean {
+    for (let col of this.templateMetadata.tableSchema.columns) {
+      if (col.name === columnRef) return true;
+    }
+    return false;
+  }
+
+  @Watch("uriTemplate")
+  private onUriTemplateChanged() {
+    this.validateUriTemplate();
+    this.$emit("input", this.uriTemplate);
+    if (this.hasErrors) {
+      this.$emit("error", this.name, this.hasErrors, this.errorMessage);
+    } else {
+      this.$emit("error", this.name, false, "");
+    }
+  }
+
+  private validateUriTemplate() {
+    let hadErrors = this.hasErrors;
+    this.errorMessage = "";
+    this.hasErrors = false;
+
+    if (this.uriTemplate.length == 0 && this.required) {
+      this.setError("A non-empty URI template string is required");
+      return;
+    }
+
+    let results = this.uriTemplate.match(this.templateRegex);
+    if (results) {
+      for (let match of results) {
+        let columnRef = match.substring(1, match.length - 1);
+        if (columnRef !== "_row" && !this.hasColumn(columnRef)) {
+          this.setError(
+            "Template references a non-existant column with name " + match
+          );
+          return;
+        }
+      }
+    } else {
+      if (!this.allowStatic) {
+        this.setError(
+          "URI Template must reference one or more columns using {columnName} syntax"
+        );
+        return;
+      }
+    }
+  }
+}
+</script>

--- a/src/DataDock.ImportUI/src/components/UriTemplateInput.vue
+++ b/src/DataDock.ImportUI/src/components/UriTemplateInput.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="field" :class="{ error: hasErrors, required: required }">
-    <label :for="name">{{ label }}</label>
-    <input :id="name" type="text" v-model="uriTemplate" />
+    <label :for="$vnode.key + '_input'">{{ label }}</label>
+    <input :id="$vnode.key + '_input'" type="text" v-model="uriTemplate" />
     <div class="ui error message" v-if="hasErrors">
       {{ errorMessage }}
     </div>

--- a/src/DataDock.ImportUI/src/views/Define.vue
+++ b/src/DataDock.ImportUI/src/views/Define.vue
@@ -100,7 +100,7 @@
           <define-columns
             v-model="templateMetadata"
             :identifierBase="identifierBase"
-            :resourceIdentifierBase="resourceIdentifierBase"
+            :resourceIdentifierBase="resourceIdentifierBase()"
             @error="onError('definitions', $event)"
           ></define-columns>
         </div>
@@ -108,7 +108,7 @@
           <define-advanced
             v-model="templateMetadata"
             :identifierBase="identifierBase"
-            :resourceIdentifierBase="resourceIdentifierBase"
+            :resourceIdentifierBase="resourceIdentifierBase()"
             @error="onError('advanced', $event)"
           ></define-advanced>
         </div>

--- a/src/DataDock.ImportUI/src/views/Upload.vue
+++ b/src/DataDock.ImportUI/src/views/Upload.vue
@@ -78,9 +78,7 @@ export default class Upload extends Vue {
       return;
     }
     let formData = new FormData();
-    let sanitizedTemplate = Helper.makeCleanTemplate(
-      this.$props.templateMetadata
-    );
+    let sanitizedTemplate = Helper.makeTemplate(this.$props.templateMetadata);
     formData.append("ownerId", this.ownerId);
     formData.append("repoId", this.repoId);
     formData.append("file", this.csvFile, this.csvFileName);

--- a/src/DataDock.ImportUI/tests/unit/DataDock.spec.ts
+++ b/src/DataDock.ImportUI/tests/unit/DataDock.spec.ts
@@ -450,5 +450,48 @@ describe("Helper", () => {
       var roundTripModel = Helper.makeTemplate(templateViewModel);
       expect(roundTripModel).toMatchObject(template);
     });
+    it("annotates new measure columns correctly", () => {
+      var templateViewModel = {
+        tableSchema: {
+          columns: [
+            {
+              name: "colA",
+              columnType: "measure",
+              propertyUrl: "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+              datatype: "integer",
+              measure: {
+                name: "colA_measure",
+                titles: ["Some Title"],
+                propertyUrl: "http://datadock.io/kal/test/id/definition/colA",
+                valueUrl: "http://datadock.io/kal/test/id/resource/colA-{_row}"
+              }
+            }
+          ]
+        }
+      };
+      var expectedTemplate = {
+        tableSchema: {
+          columns: [
+            {
+              name: "colA",
+              "http://schema.datadock.io/columnType": "measure",
+              aboutUrl: "http://datadock.io/kal/test/id/resource/colA-{_row}",
+              propertyUrl: "http://www.w3.org/1999/02/22-rdf-syntax-ns#value",
+              datatype: "integer"
+            },
+            {
+              name: "colA_measure",
+              titles: ["Some Title"],
+              propertyUrl: "http://datadock.io/kal/test/id/definition/colA",
+              valueUrl: "http://datadock.io/kal/test/id/resource/colA-{_row}",
+              virtual: true
+            }
+          ]
+        }
+      };
+
+      var template = Helper.makeTemplate(templateViewModel);
+      expect(template).toMatchObject(expectedTemplate);
+    });
   });
 });

--- a/src/DataDock.Web/ViewModels/PortalViewModel.cs
+++ b/src/DataDock.Web/ViewModels/PortalViewModel.cs
@@ -81,9 +81,13 @@ namespace DataDock.Web.ViewModels
 
         private List<SearchButton> GetSearchButtons(string searchButtonsString)
         {
+            var searchButtons = new List<SearchButton>();
+            if (string.IsNullOrEmpty(searchButtonsString))
+            {
+                return searchButtons;
+            }
             try
             {
-                var searchButtons = new List<SearchButton>();
 
                 var sbSplit = searchButtonsString.Split(',');
                 foreach (var b in sbSplit)
@@ -104,13 +108,14 @@ namespace DataDock.Web.ViewModels
                         searchButtons.Add(sb);
                     }
                 }
+
                 return searchButtons;
             }
             catch (Exception e)
             {
-               Log.Error(e, "Error building search buttons from string saved to owner settings");
+                Log.Error(e, "Error building search buttons from string saved to owner settings");
             }
-            return new List<SearchButton>();
+            return searchButtons;
         }
     }
 

--- a/src/DataDock.Worker/DataDock.Worker.csproj
+++ b/src/DataDock.Worker/DataDock.Worker.csproj
@@ -30,4 +30,10 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="logsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/DataDock.Worker/DataDock.Worker.csproj
+++ b/src/DataDock.Worker/DataDock.Worker.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\DataDock.Common\DataDock.Common.csproj" />
-    <PackageReference Include="DataDock.CsvWeb" Version="0.1.0-pre0005" />
+    <PackageReference Include="DataDock.CsvWeb" Version="0.1.0-pre0008" />
     <PackageReference Include="DotLiquid" Version="2.0.314" />
     <PackageReference Include="dotNetRDF" Version="2.4.0" />
     <PackageReference Include="Elasticsearch.Net" Version="6.8.3" />


### PR DESCRIPTION
Added support for specifying that a column contains a measure. A measure is a small fragment of data that has a value and one or more other properties (called facets) attached to it. Facets are fixed values so they are the same for every measure created for the same column.