### PR TITLE
Update metadata positioning of aboutUrl

### DIFF
--- a/src/DataDock.ImportUI/src/App.vue
+++ b/src/DataDock.ImportUI/src/App.vue
@@ -163,8 +163,9 @@ export default class App extends Vue {
       "dc:description": "",
       "dc:license": "",
       "dcat:keyword": [],
-      aboutUrl: this.identifierBase + "/resource/" + datasetId + "/row_{_row}",
-      tableSchema: {}
+      tableSchema: {
+        aboutUrl: this.identifierBase + "/resource/" + datasetId + "/row_{_row}"
+      }
     };
     templateMetadata.tableSchema.columns = [];
     let sniffer = new DatatypeSniffer(new SnifferOptions());

--- a/src/DataDock.Web/editor_test.html
+++ b/src/DataDock.Web/editor_test.html
@@ -56,8 +56,8 @@
                     "transport"
                 ],
                 "dc:license": "https://creativecommons.org/publicdomain/zero/1.0/",
-                "aboutUrl": "id/resource/stop/{stop}",
                 "tableSchema": {
+                    "aboutUrl": "id/resource/stop/{stop}",
                     "columns": [
                         {
                             "name": "stop",

--- a/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
+++ b/src/DataDock.Web/wwwroot/js/datadock.schemahelper.js
@@ -61,7 +61,8 @@
     }
 
     this.getAboutUrl = function(metadata) {
-        return getPropertyValue(metadata, "aboutUrl", null);
+        var tableSchema = getPropertyValue(metadata, "tableSchema", null);
+        return getPropertyValue(tableSchema, "aboutUrl", null);
     };
 
     this.getColumnTitle = function(colTemplate, defaultValue) {

--- a/src/DataDock.Worker.Tests/ImportSchemeProcessorSpec.cs
+++ b/src/DataDock.Worker.Tests/ImportSchemeProcessorSpec.cs
@@ -65,8 +65,8 @@ namespace DataDock.Worker.Tests
                 'url': 'http://datadock.io/datadock/test/id/dataset/mydataset',
                 'dc:title': 'http://datadock.io/datadock/test/foo',
                 'dc:license': 'https://creativecommons.org/publicdomain/zero/1.0/',
-                'aboutUrl': 'http://datadock.io/datadock/test/id/resource/mydataset/monument_record_no/{monument_record_no}', 
                 'tableSchema': {
+                    'aboutUrl': 'http://datadock.io/datadock/test/id/resource/mydataset/monument_record_no/{monument_record_no}', 
                     'columns': [
                         {
                             'name' : 'foo',
@@ -84,10 +84,10 @@ namespace DataDock.Worker.Tests
                 SchemaFileId = "schemaFileId"
             };
             await proc.ProcessJob(job, new UserAccount(), _mockProgressLog.Object);
-            _mockSchemeStore.Verify(s=>s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p=>
-                (p.Schema["aboutUrl"] as JValue).Value<string>().Equals("id/resource/mydataset/monument_record_no/{monument_record_no}"))));
             _mockSchemeStore.Verify(s => s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p =>
                 (p.Schema["dc:title"] as JValue).Value<string>().Equals("http://datadock.io/datadock/test/foo"))));
+            _mockSchemeStore.Verify(s=>s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p=>
+                (p.Schema["tableSchema"]["aboutUrl"] as JValue).Value<string>().Equals("id/resource/mydataset/monument_record_no/{monument_record_no}"))));
             _mockSchemeStore.Verify(s => s.CreateOrUpdateSchemaRecordAsync(It.Is<SchemaInfo>(p =>
                 (p.Schema["tableSchema"]["columns"][0]["propertyUrl"] as JValue).Value<string>()
                 .Equals("id/definition/foo"))));


### PR DESCRIPTION
In order for our metadata templates/files to be valid CSVW, `aboutUrl` should be a child of `tableSchema` - see [CSVW Primer](https://www.w3.org/TR/tabular-data-primer/#h-row-identifiers)

This PR is waiting for bugfix #250 to be completed before testing can be completed