### PR TITLE
Include appsettings in Worker build

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -19,6 +19,8 @@
 
 - Fill out local config in `/src/DataDock.Web/appsettings.development.json` (create if none exists, this file is excluded from git)
 
+- Fill out local config in `/src/DataDock.Worker/appsettings.development.json` (create if none exists, this file is excluded from git)
+
 If developing using Visual Studio Code, add these tasks to your `tasks.json`:
 
 ```json

--- a/src/DataDock.Common/DataDock.Common.csproj
+++ b/src/DataDock.Common/DataDock.Common.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="NEST" Version="6.8.3" />
     <PackageReference Include="NEST.JsonNetSerializer" Version="6.8.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Octokit" Version="0.36.0" />
+    <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />

--- a/src/DataDock.Common/GitHubClientFactory.cs
+++ b/src/DataDock.Common/GitHubClientFactory.cs
@@ -47,6 +47,7 @@ namespace DataDock.Common
         public GitHubClient CreateClient(string accessToken)
         {
             if (accessToken == null) throw new ArgumentNullException(nameof(accessToken));
+            Log.Information($"Creating github client for {_productHeaderValue}");
             var client = new GitHubClient(new ProductHeaderValue(_productHeaderValue))
             {
                 Credentials = new Credentials(accessToken)

--- a/src/DataDock.Web/DataDock.Web.csproj
+++ b/src/DataDock.Web/DataDock.Web.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="3.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
-    <PackageReference Include="Octokit" Version="0.36.0" />
+    <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Elasticsearch" Version="7.1.0" />

--- a/src/DataDock.Worker/DataDock.Worker.csproj
+++ b/src/DataDock.Worker/DataDock.Worker.csproj
@@ -36,4 +36,13 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="appsettings.*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/DataDock.Worker/DataDock.Worker.csproj
+++ b/src/DataDock.Worker/DataDock.Worker.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.2" />
-    <PackageReference Include="Octokit" Version="0.36.0" />
+    <PackageReference Include="Octokit" Version="0.51.0" />
     <PackageReference Include="Polly" Version="7.2.0" />
     <PackageReference Include="Quince" Version="0.6.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />


### PR DESCRIPTION
Visual Studio code was not including the appsettings.development.json, firstly because I hadn't created it locally (!) but also because the build was then not picking it up. It seems Visual Studio Code needs to know about the files in the `csproj` file for it to be picked up by the `dotnet run build` task.

This resulted in a failure to create a github client needed to create a release, or lookup user profile details

Also added/edited a few log messages

Updated Octokit to 0.51.0 as part of the investigation into why the github client was failing. This closes #256 