### PR TITLE
Improve handling of error responses

### DIFF
--- a/src/DataDock.ImportUI/src/views/Upload.vue
+++ b/src/DataDock.ImportUI/src/views/Upload.vue
@@ -121,10 +121,20 @@ export default class Upload extends Vue {
         }
       })
       .catch(error => {
-        if (error.response && "responseText" in error.response.data) {
-          this.errors.push(
-            "Publish API has reported an error: " + error.response.responseText
-          );
+        if (error.response && error.response.data) {
+          if (typeof error.response.data === 'string') {
+            this.errors.push(
+              "Publish API has reported an error: " + error.response.data)
+          } else if (Array.isArray(error.response.data)) {
+            this.errors.push("Publish API has reported errors")
+            error.response.data.forEach((x: any) => this.errors.push(x))
+          } else if ('responseText' in error.response.data) {
+            this.errors.push(
+              "Publish API has reported an error: " + error.response.data.responseText
+            );
+          } else {
+            this.errors.push("Publis API has reported an error: " + JSON.stringify(error.response.data))
+          }
         } else {
           this.errors.push("Publish API has returned an unspecified error.");
         }


### PR DESCRIPTION
Update handling of error responses from the DataController to properly handle responses that contain either a plain string (used for most POST errors) or an array of strings (used when there are validation errors)
Fixes #259